### PR TITLE
fix: concurrent listRepos callers bypass allowedRepos filter

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1594,6 +1594,26 @@ describe("allowedRepos filtering", () => {
     expect(second).toHaveLength(2);
     expect(second.map(r => r.name).sort()).toEqual(["repo-b", "test-repo"]);
   });
+
+  it("concurrent callers get filtered repos, not raw fetch results", async () => {
+    vi.useFakeTimers();
+    (config as any).ALLOWED_REPOS = ["repo-a"];
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
+      // Simulate async delay so both calls are in-flight concurrently
+      setTimeout(() => cb(null, JSON.stringify(threeRepos), ""), 100);
+    });
+
+    const p1 = listRepos();
+    const p2 = listRepos();
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    // Both callers must see the filtered result (repo-a + self-repo)
+    expect(r1.map(r => r.name).sort()).toEqual(["repo-a", "test-repo"]);
+    expect(r2.map(r => r.name).sort()).toEqual(["repo-a", "test-repo"]);
+    vi.useRealTimers();
+  });
 });
 
 describe("apiCache TTL for listIssuesByLabel", () => {

--- a/src/github.ts
+++ b/src/github.ts
@@ -313,14 +313,13 @@ export async function listRepos(): Promise<Repo[]> {
     return repoCache.repos;
   }
 
-  // Deduplicate concurrent calls: if a fetch is already in flight, reuse it
+  // Deduplicate concurrent calls: if a fetch-and-filter is already in flight, reuse it
   if (repoCachePromise) {
     return repoCachePromise;
   }
 
-  repoCachePromise = fetchRepos();
-  try {
-    const fetched = await repoCachePromise;
+  repoCachePromise = (async () => {
+    const fetched = await fetchRepos();
 
     // If the fetch returned empty but we had repos before, a transient error
     // (e.g. rate limit) likely caused all owners to fail. Return stale cache.
@@ -332,6 +331,10 @@ export async function listRepos(): Promise<Repo[]> {
     const repos = filterRepos(fetched);
     repoCache = { repos, fetchedAt: Date.now() };
     return repos;
+  })();
+
+  try {
+    return await repoCachePromise;
   } finally {
     repoCachePromise = null;
   }


### PR DESCRIPTION
## Summary

- **Bug:** When multiple jobs called `listRepos()` concurrently (e.g. on startup), the dedup logic shared the raw `fetchRepos()` promise. The first caller applied `filterRepos()` after awaiting, but concurrent callers received the unfiltered result — bypassing `allowedRepos` entirely.
- **Fix:** Wrap fetch + filter + cache-update into the shared promise (IIFE) so all callers get the filtered result.
- **Evidence:** Server logs showed `repo-standards` syncing labels for 7 repos (snosi, intuneme, updex, nbc, chairlift, cayo) and `issue-refiner` posting plans for cayo issues — all outside the configured `allowedRepos: ["yeti"]`.

## Test plan

- [x] Added regression test: concurrent `listRepos()` callers with `ALLOWED_REPOS` set must both receive filtered results
- [x] All 2776 existing tests pass
- [x] Build passes
- [x] Deployed to server — verified `repo-standards` now only syncs labels for `frostyard/yeti`

🤖 Generated with [Claude Code](https://claude.com/claude-code)