### PR TITLE
fix: resolve #15 — dashboard config missing fields

### DIFF
--- a/src/pages/config.ts
+++ b/src/pages/config.ts
@@ -14,6 +14,7 @@ export function buildConfigPage(saved: boolean, theme: Theme): string {
     slackWebhook: "YETI_SLACK_WEBHOOK",
     slackBotToken: "YETI_SLACK_BOT_TOKEN",
     slackIdeasChannel: "YETI_SLACK_IDEAS_CHANNEL",
+    allowedRepos: "YETI_ALLOWED_REPOS",
     githubOwners: "YETI_GITHUB_OWNERS",
     selfRepo: "YETI_SELF_REPO",
     port: "PORT",
@@ -69,6 +70,17 @@ ${htmlOpenTag(theme)}
 
     <label for="logRetentionPerJob">Min Logs Kept Per Job</label>
     <input type="number" name="logRetentionPerJob" id="logRetentionPerJob" value="${Number(cfg.logRetentionPerJob)}" min="0">
+
+    <h2>Jobs &amp; Repos</h2>
+    <label for="enabledJobs">Enabled Jobs (comma-separated)</label>
+    <input type="text" name="enabledJobs" id="enabledJobs" value="${escapeHtml(Array.isArray(cfg.enabledJobs) ? (cfg.enabledJobs as string[]).join(", ") : "")}">
+    <div class="field-note">Valid jobs: issue-refiner, issue-worker, ci-fixer, review-addresser, doc-maintainer, auto-merger, repo-standards, improvement-identifier, issue-auditor, triage-yeti-errors</div>
+    <div class="field-note">Empty means no jobs will run.</div>
+
+    <label for="allowedRepos">Allowed Repos (comma-separated short names)</label>
+    <input type="text" name="allowedRepos" id="allowedRepos" value="${escapeHtml(Array.isArray(cfg.allowedRepos) ? (cfg.allowedRepos as string[]).join(", ") : "")}"${isDisabled("allowedRepos") ? " disabled" : ""}>
+    ${envNote("allowedRepos")}
+    <div class="field-note">Restricts which repos Yeti processes. Empty means no repos (use with caution). To allow all repos, remove the allowedRepos key from config.json.</div>
 
     <h2>Server</h2>
     <label for="port">Port</label>

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -22,6 +22,8 @@ vi.mock("./config.js", () => ({
     schedules: { docMaintainerHour: 1, repoStandardsHour: 2, improvementIdentifierHour: 3 },
     logRetentionDays: 14,
     logRetentionPerJob: 20,
+    enabledJobs: ["issue-worker", "ci-fixer"],
+    allowedRepos: ["repo1", "repo2"],
   }),
   writeConfig: vi.fn(),
   SKIPPED_ITEMS: [],
@@ -323,6 +325,77 @@ describe("HTTP server", () => {
     expect(res.status).toBe(303);
     expect(res.headers.location).toBe("/config?saved=1");
     expect(wc).toHaveBeenCalled();
+  });
+
+  it("POST /config parses comma-separated enabledJobs", async () => {
+    const { writeConfig: wc } = await import("./config.js");
+    await request(server, "POST", "/config", {
+      body: "enabledJobs=ci-fixer%2C%20auto-merger",
+    });
+    expect(wc).toHaveBeenCalledWith(
+      expect.objectContaining({ enabledJobs: ["ci-fixer", "auto-merger"] }),
+    );
+  });
+
+  it("POST /config parses empty enabledJobs as empty array", async () => {
+    const { writeConfig: wc } = await import("./config.js");
+    await request(server, "POST", "/config", {
+      body: "enabledJobs=",
+    });
+    expect(wc).toHaveBeenCalledWith(
+      expect.objectContaining({ enabledJobs: [] }),
+    );
+  });
+
+  it("POST /config parses comma-separated allowedRepos", async () => {
+    const { writeConfig: wc } = await import("./config.js");
+    await request(server, "POST", "/config", {
+      body: "allowedRepos=repo1%2C%20repo2",
+    });
+    expect(wc).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedRepos: ["repo1", "repo2"] }),
+    );
+  });
+
+  it("POST /config parses empty allowedRepos as empty array", async () => {
+    const { writeConfig: wc } = await import("./config.js");
+    await request(server, "POST", "/config", {
+      body: "allowedRepos=",
+    });
+    expect(wc).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedRepos: [] }),
+    );
+  });
+
+  it("GET /config renders enabledJobs and allowedRepos fields", async () => {
+    const res = await request(server, "GET", "/config");
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('name="enabledJobs"');
+    expect(res.body).toContain('name="allowedRepos"');
+    expect(res.body).toContain("issue-worker, ci-fixer");
+    expect(res.body).toContain("repo1, repo2");
+  });
+
+  it("GET /config renders allowedRepos as empty when null", async () => {
+    const { getConfigForDisplay } = await import("./config.js");
+    (getConfigForDisplay as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      slackWebhook: "****cdef",
+      githubOwners: ["owner1"],
+      selfRepo: "owner1/repo1",
+      authToken: "Not configured",
+      port: 9384,
+      intervals: { issueWorkerMs: 300000 },
+      schedules: { docMaintainerHour: 1 },
+      logRetentionDays: 14,
+      logRetentionPerJob: 20,
+      enabledJobs: [],
+      allowedRepos: null,
+    });
+    const res = await request(server, "GET", "/config");
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('name="allowedRepos"');
+    // null allowedRepos should render as empty value
+    expect(res.body).toMatch(/name="allowedRepos"[^>]*value=""/);
   });
 
   it("GET /login redirects to / when auth disabled", async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -327,6 +327,13 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
     if (params["discordAllowedUsers"] !== undefined) {
       updates.discordAllowedUsers = params["discordAllowedUsers"].split(",").map(s => s.trim()).filter(Boolean);
     }
+    // Jobs & Repos
+    if (params["enabledJobs"] !== undefined) {
+      updates.enabledJobs = params["enabledJobs"].split(",").map(s => s.trim()).filter(Boolean);
+    }
+    if (params["allowedRepos"] !== undefined) {
+      updates.allowedRepos = params["allowedRepos"].split(",").map(s => s.trim()).filter(Boolean);
+    }
     // Intervals
     const intervalUpdates: Record<string, number> = {};
     for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
## Summary

Adds `enabledJobs` and `allowedRepos` fields to the web dashboard config editor, resolving #15. These fields were configurable via `config.json` and env vars but couldn't be viewed or edited through the UI, making it easy to misconfigure which jobs run and which repos are processed.

## Changes

- Added "Jobs & Repos" section to the config page with comma-separated input fields for `enabledJobs` and `allowedRepos`
- Added server-side parsing of both fields on `POST /config`, splitting comma-separated values into arrays
- Registered `allowedRepos` in the env-var override map so the field shows as disabled when set via `YETI_ALLOWED_REPOS`
- Added field notes documenting valid job names and the behavior of empty values
- Added tests covering parsing (comma-separated, empty), rendering, and null `allowedRepos` handling

Closes #15