### PR TITLE
fix: resolve #17 — Update CLAUDE.md to force consideration of web dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ npx vitest run -t "returns ms until"          # run tests matching a name patter
 - **TDD** - Use TDD (test driven development) for all code changes
 - **Worktrees** - Use git worktrees
 - **Branching** - Before making any changes, create a branch. One branch per plan.
+- **Dashboard awareness** — Any change to config fields, job behavior, queue categories, or status data must be reflected in the web dashboard (`src/server.ts` and `src/pages/`). Before considering a task complete, check whether the dashboard needs updates: new config fields need form controls in `src/pages/config.ts`, new job states or queue categories need display in `src/pages/dashboard.ts` or `src/pages/queue.ts`, and changes to log/task schemas need corresponding updates in `src/pages/logs.ts`.
 
 ## Architecture
 
@@ -72,6 +73,12 @@ Tests are co-located (`*.test.ts` next to source). Heavy mocking of external bou
 - Release tarball: `dist/` + `deploy/` + `node_modules/`
 - Health check: `GET /health` on port 9384
 
-## Deployment Scripts
+## Cross-Cutting Concerns
 
-After any change to `src/config.ts` (new config fields, removed fields, env var changes), update the bootstrap templates in `deploy/install.sh` to match. Also review `deploy/deploy.sh` if the deployment lifecycle changes.
+After any change to `src/config.ts` (new config fields, removed fields, env var changes), update both `deploy/install.sh` **and** `src/pages/config.ts`.
+
+After any change to job behavior or queue categories, review `src/pages/dashboard.ts` and `src/pages/queue.ts`.
+
+After adding or changing API routes in `src/server.ts`, ensure corresponding page builders in `src/pages/` are updated.
+
+Also review `deploy/deploy.sh` if the deployment lifecycle changes.

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -220,6 +220,10 @@ file context.
 
 **`discord.ts`** — Discord bot integration using discord.js. Connects as a bot user, sends notifications to a configured channel, and handles `!yeti` commands from authorised users. Commands: `status`, `jobs`, `trigger <job>`, `pause <job>`, `resume <job>`, `help`. Requires `discordBotToken`, `discordChannelId`, and `discordAllowedUsers` in config. Only processes messages from the configured channel and from users in the allow-list. Uses `console.log` for its own error output to avoid recursive notify loops. The scheduler reference is injected at startup to enable job control commands. See [Discord Setup](discord-setup.md).
 
+### Dashboard (`src/pages/`)
+
+The web dashboard is a first-class consumer of job, config, and queue data. Page builders in `src/pages/` render HTML for the dashboard routes in `server.ts`. Any changes to config fields, job states, queue categories, or log/task schemas must be reflected in the corresponding page builders — the dashboard is not optional.
+
 ## Jobs
 
 Ten scheduled jobs run on timers or schedules, plus one event-driven handler.


### PR DESCRIPTION
## Summary

Resolves #17. Several PRs have shipped changes that ignored the web dashboard, so this adds explicit guidance to CLAUDE.md and OVERVIEW.md ensuring the dashboard is always considered when making changes to config, jobs, queues, or status data.

## Changes

- Added a **Dashboard awareness** bullet to the Development section of CLAUDE.md, requiring dashboard updates for any change to config fields, job behavior, queue categories, or status data
- Renamed the "Deployment Scripts" section to **Cross-Cutting Concerns** and expanded it with dashboard-specific reminders (config → `pages/config.ts`, jobs → `pages/dashboard.ts`/`pages/queue.ts`, routes → page builders)
- Added a **Dashboard (`src/pages/`)** subsection to OVERVIEW.md describing the dashboard as a first-class consumer of job, config, and queue data

Closes #17