### PR TITLE
refactor: Remove unused yaml dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^12",
-        "discord.js": "^14.25.1",
-        "yaml": "^2.8.2"
+        "discord.js": "^14.25.1"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7",
@@ -2553,7 +2552,10 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12",
-    "discord.js": "^14.25.1",
-    "yaml": "^2.8.2"
+    "discord.js": "^14.25.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7",


### PR DESCRIPTION
The `yaml` package is listed in `package.json` (line 16) but is never imported anywhere in the codebase. No `import` or `require` for `yaml` exists in any source file. Remove it from `dependencies` to reduce install size and eliminate an unnecessary dependency.

---
*Automated improvement by yeti improvement-identifier*