### PR TITLE
refactor: Remove dead export clearSelfLoginCache

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -226,10 +226,6 @@ export function clearQueueCache(): void {
 
 let _selfLogin: string | null = null;
 
-export function clearSelfLoginCache(): void {
-  _selfLogin = null;
-}
-
 export async function getSelfLogin(): Promise<string> {
   if (!_selfLogin) {
     const raw = await gh(["api", "user", "--jq", ".login"]);


### PR DESCRIPTION
`clearSelfLoginCache()` in `src/github.ts` (line 229) is exported but never imported or called anywhere in the codebase — not in production code, not in tests. It was likely intended for test teardown but was never wired up. Remove the export to reduce dead code.

---
*Automated improvement by yeti improvement-identifier*