### PR TITLE
refactor: Guard against empty GITHUB_OWNERS in discord resolveRepo

### DIFF
--- a/src/discord.test.ts
+++ b/src/discord.test.ts
@@ -353,6 +353,20 @@ describe("start and commands", () => {
 
   // ── issue command ──
 
+  it("!yeti issue replies with error when GITHUB_OWNERS is empty", async () => {
+    mockConfig.GITHUB_OWNERS = [];
+    const scheduler = makeScheduler();
+    await start(scheduler);
+    const msg = makeMessage({ content: "!yeti issue snosi Fix bug" });
+    mockEventHandlers["messageCreate"](msg);
+    await vi.waitFor(() => {
+      expect(msg.reply).toHaveBeenCalled();
+    });
+    expect(gh.createIssue).not.toHaveBeenCalled();
+    expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("GITHUB_OWNERS is not configured"));
+    mockConfig.GITHUB_OWNERS = ["frostyard"];
+  });
+
   it("!yeti issue creates issue with valid repo and title", async () => {
     const scheduler = makeScheduler();
     await start(scheduler);

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -122,6 +122,9 @@ export async function stop(): Promise<void> {
 }
 
 function resolveRepo(shortName: string): string {
+  if (GITHUB_OWNERS.length === 0) {
+    throw new Error("GITHUB_OWNERS is not configured");
+  }
   return `${GITHUB_OWNERS[0]}/${shortName}`;
 }
 


### PR DESCRIPTION
`src/discord.ts` line 124-125: `resolveRepo()` unconditionally accesses `GITHUB_OWNERS[0]` without checking that the array is non-empty. If `githubOwners` is configured as an empty array (which the config system allows), this will produce `undefined/repoName` as the repo string, causing silent failures in all Discord commands that resolve repos (`!yeti issue`, `!yeti look`, `!yeti assign`). Add a guard that logs an error or throws when `GITHUB_OWNERS` is empty.

---
*Automated improvement by yeti improvement-identifier*