### PR TITLE
fix: auto-merger ignores improve PRs and CI checks not linked to PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
       - "docs/**"
       - "**/*.md"
       - LICENSE
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - LICENSE
 
 jobs:
   build:

--- a/src/jobs/auto-merger.test.ts
+++ b/src/jobs/auto-merger.test.ts
@@ -242,4 +242,26 @@ describe("auto-merger", () => {
     expect(mockGh.hasValidLGTM).not.toHaveBeenCalled();
     expect(mockGh.mergePR).toHaveBeenCalledWith(repo.fullName, pr.number);
   });
+
+  it("merges improve PR when checks pass and LGTM is valid", async () => {
+    const pr = mockPR({ headRefName: "yeti/improve-ab12" });
+    mockGh.listPRs.mockResolvedValue([pr]);
+    mockGh.hasValidLGTM.mockResolvedValue(true);
+    mockGh.getPRCheckStatus.mockResolvedValue("passing");
+
+    await run([repo]);
+
+    expect(mockGh.hasValidLGTM).toHaveBeenCalledWith(repo.fullName, pr.number, "main");
+    expect(mockGh.mergePR).toHaveBeenCalledWith(repo.fullName, pr.number);
+  });
+
+  it("skips improve PR without valid LGTM", async () => {
+    const pr = mockPR({ headRefName: "yeti/improve-ab12" });
+    mockGh.listPRs.mockResolvedValue([pr]);
+    mockGh.hasValidLGTM.mockResolvedValue(false);
+
+    await run([repo]);
+
+    expect(mockGh.mergePR).not.toHaveBeenCalled();
+  });
 });

--- a/src/jobs/auto-merger.ts
+++ b/src/jobs/auto-merger.ts
@@ -14,7 +14,7 @@ export async function run(repos: Repo[]): Promise<void> {
         if (gh.isItemSkipped(repo.fullName, pr.number)) continue;
         try {
           const isDependabot = pr.author.login === "dependabot[bot]";
-          const isYetiPR = pr.headRefName.startsWith("yeti/issue-");
+          const isYetiPR = pr.headRefName.startsWith("yeti/issue-") || pr.headRefName.startsWith("yeti/improve-");
           const isDocPR = pr.headRefName.startsWith("yeti/docs-");
 
           if (!isDependabot && !isYetiPR && !isDocPR) continue;


### PR DESCRIPTION
## Summary

- **improve PRs skipped:** Auto-merger only recognized `yeti/issue-*` and `yeti/docs-*` branch patterns. PRs with `yeti/improve-*` branches (from improvement-identifier) were silently skipped even with LGTM comments.
- **CI checks invisible to PRs:** The CI workflow only triggered on `push`, not `pull_request`, so GitHub never associated check results with PRs. `gh pr checks` returned "no checks reported" and auto-merger treated them as not passing.

## Test plan

- [x] Added tests for `yeti/improve-*` PR merge (with and without LGTM)
- [x] All 2750 tests pass
- [x] Build passes
- [x] Deployed auto-merger fix to server — immediately merged PR #26 (`yeti/improve-0425`)
- [ ] CI workflow change will take effect once merged — future PRs will have check status

🤖 Generated with [Claude Code](https://claude.com/claude-code)