### PR TITLE
docs: update documentation for yeti

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -193,8 +193,8 @@ logs are associated with the job run that produced them.
 
 **`error-reporter.ts`** — On error: logs to console (+ Discord via notify), then (with a
 30-minute per-fingerprint cooldown) either comments on an existing
-`[yeti-error]` issue in `SELF_REPO` or creates a new one with the
-`yeti-error` label. These issues are then picked up by the
+`[yeti-error]` issue in `SELF_REPO` or creates a new one (no label
+applied — discovery is by title pattern). These issues are then picked up by the
 triage-yeti-errors job for automated investigation. Two error types are
 filtered before any reporting: `ShutdownError` (logged at info level —
 shutdown cancellations are expected) and `RateLimitError` (logged at warn

--- a/yeti/jobs.md
+++ b/yeti/jobs.md
@@ -290,8 +290,8 @@ For each canonical (non-duplicate) issue:
 Scans all open PRs per repo. For each PR:
 
 - **Dependabot PRs** (`dependabot[bot]` author): merges if all CI checks pass
-- **Yeti PRs** (`yeti/issue-` branch prefix): merges if the PR has a valid
-  LGTM comment AND all CI checks pass. LGTM validation uses
+- **Yeti PRs** (`yeti/issue-` or `yeti/improve-` branch prefix): merges if
+  the PR has a valid LGTM comment AND all CI checks pass. LGTM validation uses
   `isYetiComment()` (marker-based) rather than self-login to identify
   Yeti-authored comments, so LGTM from a shared GitHub account is accepted.
   Merge-from-base commits (e.g. from ci-fixer resolving conflicts) do not


### PR DESCRIPTION
## Summary

Updates project documentation to reflect recent code changes in error reporting and auto-merger behavior. The error-reporter no longer applies a `yeti-error` label when creating issues (discovery is by title pattern instead), and the auto-merger now recognizes `yeti/improve-` branch prefixes in addition to `yeti/issue-` prefixes.

## Changes

- **yeti/OVERVIEW.md**: Corrected error-reporter description to note that new error issues are created without a label, with discovery based on title pattern matching
- **yeti/jobs.md**: Updated auto-merger documentation to include `yeti/improve-` as a recognized branch prefix for Yeti PRs eligible for automatic merging