### PR TITLE
fix: resolve #29 — discord dashboard integration

### DIFF
--- a/src/discord.test.ts
+++ b/src/discord.test.ts
@@ -487,6 +487,22 @@ describe("start and commands", () => {
     expect(msg.reply).toHaveBeenCalledWith("Unknown repo: **badrepo**");
   });
 
+  it("sets lastResult to ok after successful ready event", async () => {
+    await start(makeScheduler());
+    await mockEventHandlers["ready"]();
+    const status = discordStatus();
+    expect(status.lastResult).toBe("ok");
+    expect(status.connected).toBe(true);
+  });
+
+  it("sets lastResult to ok after shardReady reconnect", async () => {
+    await start(makeScheduler());
+    await mockEventHandlers["shardReady"]();
+    const status = discordStatus();
+    expect(status.lastResult).toBe("ok");
+    expect(status.connected).toBe(true);
+  });
+
   it("stop destroys client", async () => {
     await start(makeScheduler());
     await stop();

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -58,6 +58,7 @@ export async function start(scheduler: Scheduler): Promise<void> {
       if (ch?.isTextBased()) {
         channel = ch as TextChannel;
         connected = true;
+        lastResult = "ok";
         log.info(`[discord] Connected as ${client!.user?.tag}`);
       } else {
         log.error(`[discord] Channel ${DISCORD_CHANNEL_ID} not found or not a text channel`);
@@ -79,6 +80,7 @@ export async function start(scheduler: Scheduler): Promise<void> {
       if (ch?.isTextBased()) {
         channel = ch as TextChannel;
         connected = true;
+        lastResult = "ok";
         log.info("[discord] Reconnected");
       }
     } catch {


### PR DESCRIPTION
## Summary

The dashboard showed Discord as "Connected (untested)" because `lastResult` was never set during the connection flow. The dashboard uses `lastResult` to determine status labels — without it being set, a connected Discord integration still appeared untested. This fix sets `lastResult = "ok"` on both initial connection (`ready` event) and reconnection (`shardReady` event).

## Changes

- Set `lastResult = "ok"` in the `ready` event handler when Discord successfully connects
- Set `lastResult = "ok"` in the `shardReady` event handler on reconnection
- Added tests verifying `lastResult` is set to `"ok"` after both `ready` and `shardReady` events

Closes #29