### PR TITLE
fix: resolve #30 — Announce new deployment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import { setShuttingDown } from "./shutdown.js";
 import { cancelQueuedTasks, cancelCurrentTask } from "./claude.js";
 import { reportError } from "./error-reporter.js";
 import { VERSION } from "./version.js";
+import { announceIfNewVersion } from "./startup-announce.js";
 
 log.info(`yeti ${VERSION} starting up`);
 
@@ -281,6 +282,8 @@ if (isDiscordConfigured()) {
   });
   log.info("Discord bot enabled");
 }
+
+announceIfNewVersion(VERSION, WORK_DIR);
 
 let shuttingDown = false;
 

--- a/src/startup-announce.test.ts
+++ b/src/startup-announce.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "node:fs";
+
+vi.mock("./notify.js", () => ({
+  notify: vi.fn(),
+}));
+
+vi.mock("./log.js", () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      readFileSync: vi.fn(),
+      writeFileSync: vi.fn(),
+    },
+  };
+});
+
+import { notify } from "./notify.js";
+import { announceIfNewVersion } from "./startup-announce.js";
+
+describe("announceIfNewVersion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("notifies and writes version file when version differs from last-version", () => {
+    vi.mocked(fs.readFileSync).mockReturnValue("v2025-01-01.1");
+
+    announceIfNewVersion("v2025-01-02.1", "/tmp/.yeti");
+
+    expect(notify).toHaveBeenCalledWith(
+      "Yeti started with updated version v2025-01-02.1",
+    );
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      "/tmp/.yeti/last-version",
+      "v2025-01-02.1",
+    );
+  });
+
+  it("notifies and creates version file on first run (file missing)", () => {
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    announceIfNewVersion("v2025-01-02.1", "/tmp/.yeti");
+
+    expect(notify).toHaveBeenCalledWith(
+      "Yeti started with updated version v2025-01-02.1",
+    );
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      "/tmp/.yeti/last-version",
+      "v2025-01-02.1",
+    );
+  });
+
+  it("does not notify when version matches last-version", () => {
+    vi.mocked(fs.readFileSync).mockReturnValue("v2025-01-02.1");
+
+    announceIfNewVersion("v2025-01-02.1", "/tmp/.yeti");
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when version is 'dev'", () => {
+    announceIfNewVersion("dev", "/tmp/.yeti");
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(fs.readFileSync).not.toHaveBeenCalled();
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("trims whitespace from stored version before comparing", () => {
+    vi.mocked(fs.readFileSync).mockReturnValue("v2025-01-02.1\n");
+
+    announceIfNewVersion("v2025-01-02.1", "/tmp/.yeti");
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+});

--- a/src/startup-announce.ts
+++ b/src/startup-announce.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+import * as log from "./log.js";
+import { notify } from "./notify.js";
+
+export function announceIfNewVersion(version: string, workDir: string): void {
+  if (version === "dev") return;
+
+  const versionFile = path.join(workDir, "last-version");
+  let lastVersion: string | null = null;
+  try {
+    lastVersion = fs.readFileSync(versionFile, "utf-8").trim();
+  } catch {
+    // First run — file doesn't exist yet
+  }
+
+  if (lastVersion !== version) {
+    notify(`Yeti started with updated version ${version}`);
+    log.info(`Announced deployment: ${version}`);
+    fs.writeFileSync(versionFile, version);
+  }
+}

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -24,6 +24,7 @@ src/
 ├── images.ts            Image/attachment extraction + download for issue/PR context
 ├── version.ts           Build-time injected version string
 ├── plan-parser.ts       Parses multi-PR implementation plans into phases
+├── startup-announce.ts  Announces new deployments via notify (version-change detection)
 ├── shutdown.ts          Graceful shutdown flag + ShutdownError class (shared across modules)
 ├── test-helpers.ts      Test factories (mockRepo, mockIssue, mockPR)
 ├── pages/
@@ -61,9 +62,11 @@ recovers orphaned tasks from a previous crash (cleans up dangling worktrees,
 marks tasks failed), prunes old logs, registers all 10 jobs with the scheduler
 (interval jobs staggered by 2 seconds to prevent thundering herd), starts the
 HTTP server, sets up live config reloading (interval and schedule changes
-propagated to the scheduler without restart), and installs SIGINT/SIGTERM handlers that cancel queued tasks,
-drain running jobs (5 min timeout), terminate active Claude processes, and
-close the database.
+propagated to the scheduler without restart), announces new deployments via
+`startup-announce.ts` (sends a notification when the version changes, skipping
+`"dev"` and same-version restarts), and installs SIGINT/SIGTERM handlers that
+cancel queued tasks, drain running jobs (5 min timeout), terminate active
+Claude processes, and close the database.
 
 **`config.ts`** — Loads configuration in priority order: environment variables >
 `~/.yeti/config.json` > hardcoded defaults. Exports `LABELS` (`refined`,
@@ -214,6 +217,12 @@ URLs, and binary attachment types. The main entry point `processTextForImages()`
 runs both pipelines and returns a combined prompt section. Used by
 issue-refiner, issue-worker, and review-addresser to give Claude visual and
 file context.
+
+**`startup-announce.ts`** — Announces new deployments. Compares the current
+`VERSION` against `~/.yeti/last-version`; if they differ (or the file doesn't
+exist), sends a notification via `notify()` and updates the file. Skips the
+announcement when `VERSION` is `"dev"` (local development) or matches the
+stored version (same-version restart / crash recovery).
 
 **`notify.ts`** — Notification dispatcher. Forwards to `discord.ts` so callers only need one import. All internal modules that send notifications import from `notify.ts`.
 


### PR DESCRIPTION
## Summary

When Yeti restarts after a new deployment, it now announces the updated version to configured messaging channels (e.g., Discord). On startup, the current version is compared against a persisted `last-version` file — if they differ (or the file doesn't exist), a notification is sent. Same-version restarts and local dev (`"dev"`) are silently skipped.

Resolves #30.

## Changes

- Added `src/startup-announce.ts` with `announceIfNewVersion()` that compares the running version against `~/.yeti/last-version`, notifies on change, and updates the file
- Integrated the announcement call in `src/main.ts` after Discord initialization
- Added comprehensive tests covering version change, first run, same-version, dev mode, and whitespace trimming
- Updated `yeti/OVERVIEW.md` with documentation for the new module

Closes #30