### PR TITLE
fix: resolve #25 — [yeti-error] issue-worker:process-issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ Jobs must be listed in the `enabledJobs` config array to run. An empty or missin
 - **Content-based state machine**: Issue/PR state is inferred from comments and reactions, not label-driven workflows.
 - **Two-phase identify/process**: Used by ci-fixer, improvement-identifier, issue-refiner — scan all items first, then process (prevents race conditions with concurrent GitHub API calls).
 - **Crash recovery**: On startup, tasks still marked `running` in DB get their worktrees cleaned and are marked `failed`.
+- **Tree-diff guard**: All PR-creating jobs gate on both `hasNewCommits` (commit count) and `hasTreeDiff` (actual tree difference via `git diff --quiet`) before pushing/creating PRs. This prevents failures when commits produce no effective changes.
+- **Fresh duplicate-PR guard**: `getOpenPRForIssue` bypasses the `listPRs` TTL cache (`fresh: true`) to avoid race conditions where a concurrent PR is invisible during the 60-second cache window.
 
 ## Testing
 

--- a/src/claude.test.ts
+++ b/src/claude.test.ts
@@ -36,7 +36,7 @@ vi.mock("node:fs", () => ({
   },
 }));
 
-import { enqueue, queueStatus, randomSuffix, datestamp, hasNewCommits, generatePRDescription, generateDocsPRDescription, regeneratePRDescription, runClaude, cancelCurrentTask, cancelQueuedTasks, createWorktree, createWorktreeFromBranch, ensureClone, ClaudeTimeoutError } from "./claude.js";
+import { enqueue, queueStatus, randomSuffix, datestamp, hasNewCommits, hasTreeDiff, generatePRDescription, generateDocsPRDescription, regeneratePRDescription, runClaude, cancelCurrentTask, cancelQueuedTasks, createWorktree, createWorktreeFromBranch, ensureClone, ClaudeTimeoutError } from "./claude.js";
 import { ShutdownError } from "./shutdown.js";
 import * as shutdown from "./shutdown.js";
 import fs from "node:fs";
@@ -195,6 +195,33 @@ describe("hasNewCommits", () => {
     });
 
     const result = await hasNewCommits("/tmp/wt", "main");
+    expect(result).toBe(false);
+  });
+});
+
+describe("hasTreeDiff", () => {
+  it("returns true when git diff --quiet exits with code 1 (tree differs)", async () => {
+    mockExecFile.mockImplementation((_cmd, args: any, _opts: any, cb: any) => {
+      if (args?.includes("diff") && args?.includes("--quiet")) {
+        const err = Object.assign(new Error("diff"), { code: 1 });
+        cb(err, "", "");
+      }
+      return undefined as any;
+    });
+
+    const result = await hasTreeDiff("/tmp/wt", "main");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when git diff --quiet exits with code 0 (identical trees)", async () => {
+    mockExecFile.mockImplementation((_cmd, args: any, _opts: any, cb: any) => {
+      if (args?.includes("diff") && args?.includes("--quiet")) {
+        cb(null, "", "");
+      }
+      return undefined as any;
+    });
+
+    const result = await hasTreeDiff("/tmp/wt", "main");
     expect(result).toBe(false);
   });
 });

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -263,6 +263,12 @@ export async function hasNewCommits(wtPath: string, baseBranch: string): Promise
   return parseInt(count, 10) > 0;
 }
 
+/** Check if the worktree tree actually differs from the base branch (guards against no-op commits). */
+export async function hasTreeDiff(wtPath: string, baseBranch: string): Promise<boolean> {
+  const result = await gitRaw(["diff", "--quiet", `origin/${baseBranch}`, "HEAD"], wtPath);
+  return result.code !== 0;
+}
+
 /** Generate a PR description by asking Claude to summarize the diff and issue. */
 export async function generatePRDescription(
   wtPath: string,

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -720,7 +720,7 @@ describe("getOpenPRForIssue (uses cached listPRs)", () => {
     expect(pr).toBeNull();
   });
 
-  it("reuses cached listPRs result", async () => {
+  it("bypasses cache for fresh duplicate-PR guard", async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
       cb(null, JSON.stringify([
         { number: 5, title: "fix: something", headRefName: "yeti/issue-42-abc1", baseRefName: "main", labels: [], author: { login: "bot" } },
@@ -731,8 +731,8 @@ describe("getOpenPRForIssue (uses cached listPRs)", () => {
     const pr = await getOpenPRForIssue("org/repo", 42);
 
     expect(pr!.number).toBe(5);
-    // Only 1 gh call despite two function calls — cache shared
-    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    // getOpenPRForIssue invalidates cache to avoid stale data — 2 calls expected
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -665,7 +665,8 @@ export async function createPR(
   }
 }
 
-export async function listPRs(repo: string): Promise<PR[]> {
+export async function listPRs(repo: string, { fresh = false }: { fresh?: boolean } = {}): Promise<PR[]> {
+  if (fresh) apiCache.invalidate(`pr-list:${repo}`);
   return apiCache.dedupedFetch(`pr-list:${repo}`, 60_000, async () => {
     const raw = await gh([
       "pr",
@@ -698,7 +699,7 @@ export async function listMergedPRsForIssue(repo: string, issueNumber: number): 
 }
 
 export async function getOpenPRForIssue(repo: string, issueNumber: number): Promise<PR | null> {
-  const prs = await listPRs(repo);
+  const prs = await listPRs(repo, { fresh: true });
   const branchPrefix = `yeti/issue-${issueNumber}-`;
   return prs.find((pr) => pr.headRefName.startsWith(branchPrefix)) ?? null;
 }

--- a/src/jobs/ci-fixer.test.ts
+++ b/src/jobs/ci-fixer.test.ts
@@ -55,6 +55,7 @@ const { mockGh, mockClaude, mockDb, MockRateLimitError } = vi.hoisted(() => {
     enqueue: vi.fn(),
     runClaude: vi.fn(),
     hasNewCommits: vi.fn(),
+    hasTreeDiff: vi.fn(),
     pushBranch: vi.fn(),
     regeneratePRDescription: vi.fn(),
     attemptMerge: vi.fn(),
@@ -96,6 +97,7 @@ describe("ci-fixer", () => {
     mockClaude.enqueue.mockImplementation((fn: () => Promise<string>) => fn());
     mockClaude.runClaude.mockResolvedValue('{"related": true, "fingerprint": "", "reason": "related to PR"}');
     mockClaude.hasNewCommits.mockResolvedValue(true);
+    mockClaude.hasTreeDiff.mockResolvedValue(true);
     mockClaude.pushBranch.mockResolvedValue(undefined);
     mockClaude.removeWorktree.mockResolvedValue(undefined);
     mockClaude.regeneratePRDescription.mockResolvedValue("## Summary\nUpdated");

--- a/src/jobs/ci-fixer.ts
+++ b/src/jobs/ci-fixer.ts
@@ -61,7 +61,7 @@ async function resolveConflicts(repo: Repo, pr: gh.PR): Promise<boolean> {
 
     await claude.enqueue(() => claude.runClaude(prompt, wtPath!), gh.hasPriorityLabel(pr.labels));
 
-    if (await claude.hasNewCommits(wtPath, pr.headRefName)) {
+    if (await claude.hasNewCommits(wtPath, pr.headRefName) && await claude.hasTreeDiff(wtPath, pr.headRefName)) {
       await claude.pushBranch(wtPath, pr.headRefName);
       try {
         const description = await claude.regeneratePRDescription(wtPath, pr.baseRefName, pr);
@@ -255,7 +255,7 @@ async function fixCI(repo: Repo, pr: gh.PR, failLog: string): Promise<void> {
 
     await claude.enqueue(() => claude.runClaude(prompt, wtPath!), gh.hasPriorityLabel(pr.labels));
 
-    if (await claude.hasNewCommits(wtPath, pr.headRefName)) {
+    if (await claude.hasNewCommits(wtPath, pr.headRefName) && await claude.hasTreeDiff(wtPath, pr.headRefName)) {
       await claude.pushBranch(wtPath, pr.headRefName);
       try {
         const description = await claude.regeneratePRDescription(wtPath, pr.baseRefName, pr);
@@ -374,7 +374,7 @@ async function revertPreviousUnrelatedFixes(
 
     await claude.enqueue(() => claude.runClaude(prompt, wtPath!), gh.hasPriorityLabel(pr.labels));
 
-    if (await claude.hasNewCommits(wtPath, pr.headRefName)) {
+    if (await claude.hasNewCommits(wtPath, pr.headRefName) && await claude.hasTreeDiff(wtPath, pr.headRefName)) {
       await claude.pushBranch(wtPath, pr.headRefName);
       log.info(`[ci-fixer] Reverted unrelated fixes for ${fullName}#${pr.number}`);
     }

--- a/src/jobs/doc-maintainer.test.ts
+++ b/src/jobs/doc-maintainer.test.ts
@@ -34,6 +34,7 @@ const { mockFs, mockGh, mockClaude, mockDb, mockPlanParser } = vi.hoisted(() => 
     enqueue: vi.fn(),
     runClaude: vi.fn(),
     hasNewCommits: vi.fn(),
+    hasTreeDiff: vi.fn(),
     pushBranch: vi.fn(),
     getHeadSha: vi.fn(),
     getLastDocMaintainerSha: vi.fn(),
@@ -77,6 +78,7 @@ describe("doc-maintainer", () => {
     mockClaude.enqueue.mockImplementation((fn: () => Promise<string>) => fn());
     mockClaude.runClaude.mockResolvedValue("docs generated");
     mockClaude.hasNewCommits.mockResolvedValue(true);
+    mockClaude.hasTreeDiff.mockResolvedValue(true);
     mockClaude.pushBranch.mockResolvedValue(undefined);
     mockClaude.removeWorktree.mockResolvedValue(undefined);
     mockClaude.getHeadSha.mockResolvedValue("abc123");

--- a/src/jobs/doc-maintainer.ts
+++ b/src/jobs/doc-maintainer.ts
@@ -142,7 +142,7 @@ async function processRepo(repo: Repo): Promise<void> {
     }
 
     // Step 5: Push and create PR
-    if (await claude.hasNewCommits(wtPath, repo.defaultBranch)) {
+    if (await claude.hasNewCommits(wtPath, repo.defaultBranch) && await claude.hasTreeDiff(wtPath, repo.defaultBranch)) {
       const description = await claude.generateDocsPRDescription(wtPath, repo.defaultBranch);
       await claude.pushBranch(wtPath, branchName);
       const prNumber = await gh.createPR(

--- a/src/jobs/improvement-identifier.test.ts
+++ b/src/jobs/improvement-identifier.test.ts
@@ -32,6 +32,7 @@ const { mockFs, mockGh, mockClaude, mockDb } = vi.hoisted(() => ({
     enqueue: vi.fn(),
     runClaude: vi.fn(),
     hasNewCommits: vi.fn(),
+    hasTreeDiff: vi.fn(),
     pushBranch: vi.fn(),
     randomSuffix: vi.fn().mockReturnValue("ab12"),
   },
@@ -76,6 +77,7 @@ describe("improvement-identifier", () => {
     mockClaude.runClaude.mockResolvedValue(`\`\`\`json\n${validResponse}\n\`\`\``);
     mockClaude.removeWorktree.mockResolvedValue(undefined);
     mockClaude.hasNewCommits.mockResolvedValue(true);
+    mockClaude.hasTreeDiff.mockResolvedValue(true);
     mockClaude.pushBranch.mockResolvedValue(undefined);
   });
 

--- a/src/jobs/improvement-identifier.ts
+++ b/src/jobs/improvement-identifier.ts
@@ -198,7 +198,7 @@ async function processRepo(repo: Repo): Promise<void> {
       const implPrompt = buildImplementationPrompt(fullName, improvement);
       await claude.enqueue(() => claude.runClaude(implPrompt, implWt!));
 
-      if (await claude.hasNewCommits(implWt, repo.defaultBranch)) {
+      if (await claude.hasNewCommits(implWt, repo.defaultBranch) && await claude.hasTreeDiff(implWt, repo.defaultBranch)) {
         await claude.pushBranch(implWt, implBranch);
         const prBody = improvement.body + FOOTER;
         await gh.createPR(fullName, implBranch, `refactor: ${improvement.title}`, prBody);

--- a/src/jobs/issue-worker.test.ts
+++ b/src/jobs/issue-worker.test.ts
@@ -46,6 +46,7 @@ const { mockGh, mockClaude, mockDb } = vi.hoisted(() => ({
     enqueue: vi.fn(),
     runClaude: vi.fn(),
     hasNewCommits: vi.fn(),
+    hasTreeDiff: vi.fn(),
     pushBranch: vi.fn(),
     generatePRDescription: vi.fn(),
     randomSuffix: vi.fn().mockReturnValue("ab12"),
@@ -84,6 +85,7 @@ describe("issue-worker", () => {
     mockClaude.enqueue.mockImplementation((fn: () => Promise<string>) => fn());
     mockClaude.runClaude.mockResolvedValue("implemented");
     mockClaude.hasNewCommits.mockResolvedValue(true);
+    mockClaude.hasTreeDiff.mockResolvedValue(true);
     mockClaude.pushBranch.mockResolvedValue(undefined);
     mockClaude.generatePRDescription.mockResolvedValue("## Summary\nFixed it");
     mockClaude.removeWorktree.mockResolvedValue(undefined);
@@ -125,6 +127,20 @@ describe("issue-worker", () => {
       const issue = mockIssue({ labels: [{ name: "Refined" }] });
       mockGh.listIssuesByLabel.mockResolvedValueOnce([issue]);
       mockClaude.hasNewCommits.mockResolvedValue(false);
+
+      await run([repo]);
+
+      expect(mockClaude.pushBranch).not.toHaveBeenCalled();
+      expect(mockGh.createPR).not.toHaveBeenCalled();
+      expect(mockGh.addLabel).not.toHaveBeenCalledWith(repo.fullName, 1, "In Review");
+      expect(mockDb.recordTaskComplete).toHaveBeenCalledWith(1);
+    });
+
+    it("commits but no tree diff — skips PR creation", async () => {
+      const issue = mockIssue({ labels: [{ name: "Refined" }] });
+      mockGh.listIssuesByLabel.mockResolvedValueOnce([issue]);
+      mockClaude.hasNewCommits.mockResolvedValue(true);
+      mockClaude.hasTreeDiff.mockResolvedValue(false);
 
       await run([repo]);
 

--- a/src/jobs/issue-worker.ts
+++ b/src/jobs/issue-worker.ts
@@ -193,7 +193,7 @@ async function processIssue(repo: Repo, issue: gh.Issue): Promise<void> {
 
     await claude.enqueue(() => claude.runClaude(prompt, wtPath!), gh.isItemPrioritized(fullName, issue.number) || gh.hasPriorityLabel(issue.labels));
 
-    if (await claude.hasNewCommits(wtPath, repo.defaultBranch)) {
+    if (await claude.hasNewCommits(wtPath, repo.defaultBranch) && await claude.hasTreeDiff(wtPath, repo.defaultBranch)) {
       await claude.pushBranch(wtPath, branchName);
       const description = await claude.generatePRDescription(
         wtPath, repo.defaultBranch, issue,

--- a/src/jobs/review-addresser.test.ts
+++ b/src/jobs/review-addresser.test.ts
@@ -40,6 +40,7 @@ const { mockGh, mockClaude, mockDb } = vi.hoisted(() => ({
     enqueue: vi.fn(),
     runClaude: vi.fn(),
     hasNewCommits: vi.fn(),
+    hasTreeDiff: vi.fn(),
     pushBranch: vi.fn(),
     regeneratePRDescription: vi.fn(),
   },
@@ -85,6 +86,7 @@ describe("review-addresser", () => {
     mockClaude.enqueue.mockImplementation((fn: () => Promise<string>) => fn());
     mockClaude.runClaude.mockResolvedValue("addressed");
     mockClaude.hasNewCommits.mockResolvedValue(true);
+    mockClaude.hasTreeDiff.mockResolvedValue(true);
     mockClaude.pushBranch.mockResolvedValue(undefined);
     mockClaude.removeWorktree.mockResolvedValue(undefined);
     mockClaude.regeneratePRDescription.mockResolvedValue("## Summary\nUpdated");

--- a/src/jobs/review-addresser.ts
+++ b/src/jobs/review-addresser.ts
@@ -38,7 +38,7 @@ async function processPR(repo: Repo, pr: gh.PR, reviewData: gh.PRReviewData): Pr
 
     const claudeOutput = await claude.enqueue(() => claude.runClaude(prompt, wtPath!), gh.hasPriorityLabel(pr.labels));
 
-    if (await claude.hasNewCommits(wtPath, pr.headRefName)) {
+    if (await claude.hasNewCommits(wtPath, pr.headRefName) && await claude.hasTreeDiff(wtPath, pr.headRefName)) {
       await claude.pushBranch(wtPath, pr.headRefName);
       try {
         const description = await claude.regeneratePRDescription(wtPath, pr.baseRefName, pr);


### PR DESCRIPTION
## Summary

Fix the `issue-worker:process-issue` error where PR creation failed with "No commits between main and branch" when Claude's changes produced commits but no effective tree difference. This adds a `hasTreeDiff` guard alongside the existing `hasNewCommits` check across all PR-creating jobs, and makes `getOpenPRForIssue` bypass the TTL cache to prevent race conditions with concurrent PR creation.

## Changes

- Add `hasTreeDiff()` utility in `src/claude.ts` that uses `git diff --quiet` to detect actual tree differences against the base branch
- Gate all PR-creating code paths on both `hasNewCommits` and `hasTreeDiff` in issue-worker, ci-fixer, doc-maintainer, improvement-identifier, and review-addresser
- Add `fresh` option to `listPRs()` that invalidates the API cache before fetching, used by `getOpenPRForIssue` to avoid stale duplicate-PR checks
- Add tests for `hasTreeDiff` and update all job test suites with the new mock
- Document tree-diff guard and fresh cache patterns in CLAUDE.md

Closes #25