### PR TITLE
fix: resolve #33 — announce deployment

### DIFF
--- a/src/discord.test.ts
+++ b/src/discord.test.ts
@@ -72,7 +72,7 @@ vi.mock("./github.js", () => ({
   ])),
 }));
 
-import { isDiscordConfigured, discordStatus, notify, start, stop } from "./discord.js";
+import { isDiscordConfigured, discordStatus, notify, start, stop, ready } from "./discord.js";
 import * as gh from "./github.js";
 import { runClaude } from "./claude.js";
 import type { Scheduler } from "./scheduler.js";
@@ -507,5 +507,48 @@ describe("start and commands", () => {
     await start(makeScheduler());
     await stop();
     expect(mockClient.destroy).toHaveBeenCalled();
+  });
+});
+
+describe("ready", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    Object.keys(mockEventHandlers).forEach((k) => delete mockEventHandlers[k]);
+  });
+
+  it("resolves immediately when Discord is not configured", async () => {
+    mockConfig.DISCORD_BOT_TOKEN = "";
+    mockConfig.DISCORD_CHANNEL_ID = "";
+    await expect(ready()).resolves.toBeUndefined();
+  });
+
+  it("resolves after the ready event fires", async () => {
+    mockConfig.DISCORD_BOT_TOKEN = "test-token";
+    mockConfig.DISCORD_CHANNEL_ID = "test-channel";
+    await start(makeScheduler());
+
+    const readyP = ready();
+    await mockEventHandlers["ready"]();
+    await expect(readyP).resolves.toBeUndefined();
+  });
+
+  it("rejects on timeout when ready event never fires", async () => {
+    vi.useFakeTimers();
+    mockConfig.DISCORD_BOT_TOKEN = "test-token";
+    mockConfig.DISCORD_CHANNEL_ID = "test-channel";
+    await start(makeScheduler());
+
+    const readyP = ready();
+    vi.advanceTimersByTime(10_000);
+    await expect(readyP).rejects.toThrow("Discord connection timeout");
+    vi.useRealTimers();
+  });
+
+  it("rejects when start was not called", async () => {
+    mockConfig.DISCORD_BOT_TOKEN = "test-token";
+    mockConfig.DISCORD_CHANNEL_ID = "test-channel";
+    // stop to clear readyPromise from any prior start
+    await stop();
+    await expect(ready()).rejects.toThrow("Discord not started");
   });
 });

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -11,9 +11,22 @@ let connected = false;
 let lastResult: "ok" | "error" | null = null;
 let schedulerRef: Scheduler | null = null;
 let startedAt: Date | null = null;
+let readyResolve: (() => void) | null = null;
+let readyPromise: Promise<void> | null = null;
 
 export function isDiscordConfigured(): boolean {
   return !!DISCORD_BOT_TOKEN && !!DISCORD_CHANNEL_ID;
+}
+
+export function ready(): Promise<void> {
+  if (!isDiscordConfigured()) return Promise.resolve();
+  if (!readyPromise) return Promise.reject(new Error("Discord not started"));
+  return Promise.race([
+    readyPromise,
+    new Promise<void>((_, reject) =>
+      setTimeout(() => reject(new Error("Discord connection timeout")), 10_000)
+    ),
+  ]);
 }
 
 export function discordStatus(): {
@@ -43,6 +56,7 @@ export async function start(scheduler: Scheduler): Promise<void> {
 
   schedulerRef = scheduler;
   startedAt = new Date();
+  readyPromise = new Promise<void>((resolve) => { readyResolve = resolve; });
 
   client = new Client({
     intents: [
@@ -59,6 +73,7 @@ export async function start(scheduler: Scheduler): Promise<void> {
         channel = ch as TextChannel;
         connected = true;
         lastResult = "ok";
+        readyResolve?.();
         log.info(`[discord] Connected as ${client!.user?.tag}`);
       } else {
         log.error(`[discord] Channel ${DISCORD_CHANNEL_ID} not found or not a text channel`);
@@ -120,6 +135,8 @@ export async function stop(): Promise<void> {
     await client.destroy();
     client = null;
     schedulerRef = null;
+    readyPromise = null;
+    readyResolve = null;
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,6 +281,10 @@ if (isDiscordConfigured()) {
     reportError("discord:start", "Discord bot failed to start", err).catch(() => {});
   });
   log.info("Discord bot enabled");
+
+  await discord.ready().catch((err) => {
+    log.warn(`[discord] Not ready for announcement: ${(err as Error).message}`);
+  });
 }
 
 announceIfNewVersion(VERSION, WORK_DIR);

--- a/src/startup-announce.test.ts
+++ b/src/startup-announce.test.ts
@@ -12,6 +12,11 @@ vi.mock("./log.js", () => ({
   debug: vi.fn(),
 }));
 
+const mockDiscordStatus = vi.fn().mockReturnValue({ configured: false, connected: false, lastResult: null });
+vi.mock("./discord.js", () => ({
+  discordStatus: (...args: unknown[]) => mockDiscordStatus(...args),
+}));
+
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   return {
@@ -25,11 +30,13 @@ vi.mock("node:fs", async () => {
 });
 
 import { notify } from "./notify.js";
+import * as log from "./log.js";
 import { announceIfNewVersion } from "./startup-announce.js";
 
 describe("announceIfNewVersion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDiscordStatus.mockReturnValue({ configured: false, connected: false, lastResult: null });
   });
 
   it("notifies and writes version file when version differs from last-version", () => {
@@ -85,5 +92,25 @@ describe("announceIfNewVersion", () => {
     announceIfNewVersion("v2025-01-02.1", "/tmp/.yeti");
 
     expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("logs 'Announced deployment' when Discord is connected", () => {
+    vi.mocked(fs.readFileSync).mockReturnValue("v2025-01-01.1");
+    mockDiscordStatus.mockReturnValue({ configured: true, connected: true, lastResult: "ok" });
+
+    announceIfNewVersion("v2025-01-02.1", "/tmp/.yeti");
+
+    expect(log.info).toHaveBeenCalledWith("Announced deployment: v2025-01-02.1");
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("logs warning when Discord is not connected", () => {
+    vi.mocked(fs.readFileSync).mockReturnValue("v2025-01-01.1");
+    mockDiscordStatus.mockReturnValue({ configured: true, connected: false, lastResult: null });
+
+    announceIfNewVersion("v2025-01-02.1", "/tmp/.yeti");
+
+    expect(log.warn).toHaveBeenCalledWith("Skipped deployment announcement (Discord not connected): v2025-01-02.1");
+    expect(log.info).not.toHaveBeenCalled();
   });
 });

--- a/src/startup-announce.ts
+++ b/src/startup-announce.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import * as log from "./log.js";
 import { notify } from "./notify.js";
+import { discordStatus } from "./discord.js";
 
 export function announceIfNewVersion(version: string, workDir: string): void {
   if (version === "dev") return;
@@ -16,7 +17,12 @@ export function announceIfNewVersion(version: string, workDir: string): void {
 
   if (lastVersion !== version) {
     notify(`Yeti started with updated version ${version}`);
-    log.info(`Announced deployment: ${version}`);
+    const status = discordStatus();
+    if (status.connected) {
+      log.info(`Announced deployment: ${version}`);
+    } else {
+      log.warn(`Skipped deployment announcement (Discord not connected): ${version}`);
+    }
     fs.writeFileSync(versionFile, version);
   }
 }


### PR DESCRIPTION
## Summary

Deployment announcements were silently failing because `announceIfNewVersion` ran before the Discord client finished connecting. The fix adds a `ready()` gate that waits (up to 10s) for the Discord `ready` event before attempting the announcement, and logs a warning if the connection isn't established in time.

## Changes

- Added `ready()` to `discord.ts` that returns a promise resolving when the Discord client fires its `ready` event, with a 10-second timeout
- Updated `main.ts` to `await discord.ready()` between `discord.start()` and `announceIfNewVersion()` so the bot is connected before sending
- Updated `startup-announce.ts` to check `discordStatus()` and log a warning instead of a success message when Discord isn't actually connected
- Added tests for the new `ready()` function (immediate resolve when unconfigured, resolve on ready event, timeout rejection, not-started rejection)
- Added tests verifying the announcement log output reflects actual Discord connection state

Closes #33