### PR TITLE
refactor: Extract duplicated tick function in scheduler to eliminate copy-paste

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -45,13 +45,8 @@ export function startJobs(jobs: Job[], initialPaused?: readonly string[]): Sched
   let draining = false;
   let intervalIndex = 0;
 
-  for (const job of jobs) {
-    runningFlags.set(job.name, false);
-    pausedFlags.set(job.name, initialPausedSet.has(job.name));
-    scheduleConfigs.set(job.name, { intervalMs: job.intervalMs, scheduledHour: job.scheduledHour });
-    jobTimers.set(job.name, []);
-
-    const tick = async (manual?: boolean) => {
+  function makeTick(job: Job): (manual?: boolean) => Promise<void> {
+    return async (manual?: boolean) => {
       if (draining) return;
 
       if (!manual && pausedFlags.get(job.name)) return;
@@ -84,6 +79,15 @@ export function startJobs(jobs: Job[], initialPaused?: readonly string[]): Sched
         }
       });
     };
+  }
+
+  for (const job of jobs) {
+    runningFlags.set(job.name, false);
+    pausedFlags.set(job.name, initialPausedSet.has(job.name));
+    scheduleConfigs.set(job.name, { intervalMs: job.intervalMs, scheduledHour: job.scheduledHour });
+    jobTimers.set(job.name, []);
+
+    const tick = makeTick(job);
 
     ticks.set(job.name, tick);
 
@@ -241,37 +245,7 @@ export function startJobs(jobs: Job[], initialPaused?: readonly string[]): Sched
     scheduleConfigs.set(job.name, { intervalMs: job.intervalMs, scheduledHour: job.scheduledHour });
     jobTimers.set(job.name, []);
 
-    const tick = async (manual?: boolean) => {
-      if (draining) return;
-      if (!manual && pausedFlags.get(job.name)) return;
-      if (runningFlags.get(job.name)) {
-        log.info(`Skipping ${job.name} — previous run still in progress`);
-        return;
-      }
-
-      const runId = crypto.randomUUID();
-      runningFlags.set(job.name, true);
-
-      try {
-        insertJobRun(runId, job.name);
-      } catch {
-        // Don't block the job if run tracking fails
-      }
-
-      await withRunContext(runId, async () => {
-        log.info(`Starting job: ${job.name}`);
-        try {
-          await job.run();
-          log.info(`Finished job: ${job.name}`);
-          try { completeJobRun(runId, "completed"); } catch { /* best effort */ }
-        } catch (err) {
-          try { completeJobRun(runId, "failed"); } catch { /* best effort */ }
-          reportError(`scheduler:${job.name}`, job.name, err);
-        } finally {
-          runningFlags.set(job.name, false);
-        }
-      });
-    };
+    const tick = makeTick(job);
 
     ticks.set(job.name, tick);
 


### PR DESCRIPTION
In `src/scheduler.ts`, the tick function body is duplicated verbatim between `startJobs()` (lines 54-86) and `addJob()` (lines 244-274). Both create a `runId`, set `runningFlags`, call `insertJobRun`, wrap with `withRunContext`, run the job, call `completeJobRun`, and handle errors identically. Extract a shared `makeTick(job)` factory function that both code paths call. This eliminates ~30 lines of duplication and ensures bug fixes apply to both paths.

---
*Automated improvement by yeti improvement-identifier*