### PR TITLE
refactor: Bound the error-reporter lastReported Map to prevent unbounded memory growth

### DIFF
--- a/src/error-reporter.test.ts
+++ b/src/error-reporter.test.ts
@@ -35,7 +35,7 @@ vi.mock("./github.js", () => {
   };
 });
 
-import { reportError } from "./error-reporter.js";
+import { reportError, _lastReported } from "./error-reporter.js";
 import { ClaudeTimeoutError } from "./claude.js";
 import { ShutdownError } from "./shutdown.js";
 import * as gh from "./github.js";
@@ -44,6 +44,7 @@ import * as log from "./log.js";
 describe("reportError", () => {
   afterEach(() => {
     mockShuttingDown = false;
+    _lastReported.clear();
     vi.clearAllMocks();
   });
 
@@ -111,6 +112,25 @@ describe("reportError", () => {
     expect(body).toContain("was actively producing output");
     expect(body).toContain("last output here");
     expect(body).toContain("stderr here");
+  });
+
+  it("evicts expired entries from lastReported on each insertion", async () => {
+    const thirtyOneMinutesAgo = Date.now() - 31 * 60 * 1000;
+    const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
+
+    // Seed with one expired and one still-active entry
+    _lastReported.set("old-fp", thirtyOneMinutesAgo);
+    _lastReported.set("recent-fp", fiveMinutesAgo);
+
+    // Report a new error, which triggers cleanup + insertion
+    await reportError("new-fp", "ctx", new Error("boom"));
+
+    // The expired entry should have been evicted
+    expect(_lastReported.has("old-fp")).toBe(false);
+    // The still-active entry should remain
+    expect(_lastReported.has("recent-fp")).toBe(true);
+    // The new entry should be present
+    expect(_lastReported.has("new-fp")).toBe(true);
   });
 
   it("includes diagnostics in recurrence comment for ClaudeTimeoutError", async () => {

--- a/src/error-reporter.ts
+++ b/src/error-reporter.ts
@@ -6,7 +6,7 @@ import * as log from "./log.js";
 import { isShuttingDown, ShutdownError } from "./shutdown.js";
 
 const COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
-const lastReported = new Map<string, number>();
+export const _lastReported = new Map<string, number>();
 
 export async function reportError(
   fingerprint: string,
@@ -36,12 +36,18 @@ export async function reportError(
   }
 
   const now = Date.now();
-  const lastTime = lastReported.get(fingerprint);
+  const lastTime = _lastReported.get(fingerprint);
   if (lastTime && now - lastTime < COOLDOWN_MS) {
     log.warn(`[error-reporter] Skipping duplicate report for "${fingerprint}" (cooldown)`);
     return;
   }
-  lastReported.set(fingerprint, now);
+
+  // Evict expired entries to prevent unbounded memory growth
+  for (const [key, timestamp] of _lastReported) {
+    if (now - timestamp >= COOLDOWN_MS) _lastReported.delete(key);
+  }
+
+  _lastReported.set(fingerprint, now);
 
   try {
     const title = `[yeti-error] ${fingerprint}`;


### PR DESCRIPTION
In `src/error-reporter.ts:9`, the `lastReported` Map grows without bound — one entry per unique fingerprint, never cleaned up. Over weeks/months of operation, this accumulates stale entries for fingerprints that will never recur. Add periodic cleanup: when inserting a new entry, evict entries older than the cooldown period (30 minutes). A simple approach is to iterate and delete expired entries before each insertion, or switch to a bounded LRU structure. Given the 30-minute cooldown, entries older than that are definitionally expired and can be safely removed.

---
*Automated improvement by yeti improvement-identifier*