### PR TITLE
refactor: Use parameterized query in pruneOldLogs to avoid SQL interpolation

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -335,17 +335,17 @@ export function hasPreviousCiFixerTasks(repo: string, prNumber: number): boolean
 
 export function pruneOldLogs(retentionDays: number, keepPerJob = 20): number {
   const d = getDb();
-  const cutoff = `datetime('now', '-${retentionDays} days')`;
+  const cutoff = new Date(Date.now() - retentionDays * 86_400_000).toISOString();
   const result = d.prepare(`
     DELETE FROM job_runs
-    WHERE started_at < ${cutoff}
+    WHERE started_at < ?
     AND id NOT IN (
       SELECT id FROM (
         SELECT id, ROW_NUMBER() OVER (PARTITION BY job_name ORDER BY started_at DESC) AS rn
         FROM job_runs
       ) WHERE rn <= ?
     )
-  `).run(keepPerJob);
+  `).run(cutoff, keepPerJob);
   d.prepare(`DELETE FROM job_logs WHERE run_id NOT IN (SELECT run_id FROM job_runs)`).run();
   return result.changes;
 }


### PR DESCRIPTION
In `src/db.ts:338`, `retentionDays` is interpolated directly into the SQL string via template literal (`datetime('now', '-${retentionDays} days')`). While `retentionDays` is a number from config, this bypasses parameterized query safety and sets a bad precedent. Replace with a parameterized approach: compute the cutoff date in JavaScript (e.g., `new Date(Date.now() - retentionDays * 86400000).toISOString()`) and pass it as a `?` parameter to the prepared statement.

---
*Automated improvement by yeti improvement-identifier*