### PR TITLE
fix: resolve #37 — mismatch in docs vs reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,14 +50,14 @@ Yeti is a self-hosted GitHub automation daemon that polls repositories on timers
 
 ### Jobs (`src/jobs/`)
 
-Each job exports a `run()` function. Jobs discover work via comment analysis, reactions, labels, and PR state — not solely labels. Four labels exist: `Refined` (trigger), `Ready` (informational), `In Review` (informational), `Priority` (queue ordering). Processed items are tracked via thumbsup reactions on comments.
+Each job exports a `run()` function. Jobs discover work via comment analysis, reactions, labels, and PR state — not solely labels. Five labels exist: `Needs Refinement` (trigger for issue-refiner), `Refined` (trigger for issue-worker), `Ready` (informational), `In Review` (informational), `Priority` (queue ordering). Processed items are tracked via thumbsup reactions on comments.
 
 Jobs must be listed in the `enabledJobs` config array to run. An empty or missing `enabledJobs` means no jobs start.
 
 ### Key patterns
 
 - **Worktree isolation**: Each task gets `~/.yeti/worktrees/<owner>/<repo>/<job>/<branch>`, cleaned up in `finally` blocks.
-- **Content-based state machine**: Issue/PR state is inferred from comments and reactions, not label-driven workflows.
+- **Content-based state machine**: Issue/PR state is inferred from comments and reactions, not label-driven workflows. Exception: the issue-refiner requires the `Needs Refinement` label to produce a new plan (machine-generated `[ci-unrelated]` and `[yeti-error]` issues are exempt).
 - **Two-phase identify/process**: Used by ci-fixer, improvement-identifier, issue-refiner — scan all items first, then process (prevents race conditions with concurrent GitHub API calls).
 - **Crash recovery**: On startup, tasks still marked `running` in DB get their worktrees cleaned and are marked `failed`.
 - **Tree-diff guard**: All PR-creating jobs gate on both `hasNewCommits` (commit count) and `hasTreeDiff` (actual tree difference via `git diff --quiet`) before pushing/creating PRs. This prevents failures when commits produce no effective changes.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ These scan all open issues/PRs and will do work without any Yeti-specific labels
 
 | Job | Trigger | What it does |
 |-----|---------|--------------|
-| **issue-refiner** | Any open issue without a plan comment | Generates an implementation plan comment |
+| **issue-refiner** | Issues labelled `Needs Refinement` | Generates an implementation plan comment |
 | **ci-fixer** | Any PR with failing checks or merge conflicts | Attempts to fix CI failures and conflicts |
 | **improvement-identifier** | Periodic scan of codebase | Creates PRs for code improvement opportunities |
 | **issue-auditor** | All open issues | Audits and classifies issue state, applies labels |

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export const LABELS = {
   ready: "Ready",
   priority: "Priority",
   inReview: "In Review",
+  needsRefinement: "Needs Refinement",
 } as const;
 
 export const LABEL_SPECS: Record<string, { color: string; description: string }> = {
@@ -20,11 +21,11 @@ export const LABEL_SPECS: Record<string, { color: string; description: string }>
   "Ready":                { color: "0e8a16", description: "Yeti has finished — needs human attention" },
   "Priority":             { color: "d93f0b", description: "High-priority — processed first in all Yeti queues" },
   "In Review":            { color: "fbca04", description: "Issue has an open PR being reviewed" },
+  "Needs Refinement":     { color: "d876e3", description: "Issue needs an AI-generated implementation plan" },
 };
 
 /** Labels that were previously managed by Yeti and can be cleaned up as stale. */
 export const LEGACY_LABELS = new Set([
-  "Needs Refinement",
   "Plan Produced",
   "Reviewed",
   "prod-report",

--- a/src/jobs/issue-refiner.test.ts
+++ b/src/jobs/issue-refiner.test.ts
@@ -6,6 +6,7 @@ vi.mock("../config.js", () => ({
     refined: "Refined",
     ready: "Ready",
     priority: "Priority",
+    needsRefinement: "Needs Refinement",
   },
 }));
 
@@ -94,7 +95,7 @@ describe("issue-refiner", () => {
   });
 
   it("happy path — new plan", async () => {
-    const issue = mockIssue({ body: "Test issue body" });
+    const issue = mockIssue({ body: "Test issue body", labels: [{ name: "Needs Refinement" }] });
     mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
 
     await run([repo]);
@@ -112,7 +113,7 @@ describe("issue-refiner", () => {
   });
 
   it("includes issue comments in fresh plan prompt", async () => {
-    const issue = mockIssue({ body: "Test issue body" });
+    const issue = mockIssue({ body: "Test issue body", labels: [{ name: "Needs Refinement" }] });
     mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
     mockGh.getIssueComments.mockResolvedValue([
       { id: 901, body: "## Yeti Error Investigation Report\n\nRoot cause: missing null check", login: "yeti-bot" },
@@ -126,7 +127,7 @@ describe("issue-refiner", () => {
   });
 
   it("empty output — logs warning but still adds Ready label", async () => {
-    const issue = mockIssue({ body: "Test issue body" });
+    const issue = mockIssue({ body: "Test issue body", labels: [{ name: "Needs Refinement" }] });
     mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
     mockClaude.runClaude.mockResolvedValue("");
 
@@ -137,7 +138,7 @@ describe("issue-refiner", () => {
   });
 
   it("error handling — records task as failed", async () => {
-    const issue = mockIssue({ body: "Test issue body" });
+    const issue = mockIssue({ body: "Test issue body", labels: [{ name: "Needs Refinement" }] });
     mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
     mockClaude.runClaude.mockRejectedValue(new Error("claude error"));
 
@@ -203,8 +204,8 @@ describe("issue-refiner", () => {
 
   it("processes multiple repos and issues, error on one does not stop others", async () => {
     const repo2 = mockRepo({ fullName: "test-org/repo2", name: "repo2" });
-    const issue1 = mockIssue({ number: 1, body: "Issue 1 body" });
-    const issue2 = mockIssue({ number: 2, body: "Issue 2 body" });
+    const issue1 = mockIssue({ number: 1, body: "Issue 1 body", labels: [{ name: "Needs Refinement" }] });
+    const issue2 = mockIssue({ number: 2, body: "Issue 2 body", labels: [{ name: "Needs Refinement" }] });
 
     mockGh.listOpenIssues
       .mockResolvedValueOnce([issue1])
@@ -225,6 +226,7 @@ describe("issue-refiner", () => {
   it("includes image context in prompt when images are found", async () => {
     const issue = mockIssue({
       body: "Add this: ![design](https://example.com/design.png)",
+      labels: [{ name: "Needs Refinement" }],
     });
     mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
     mockGh.getIssueComments.mockResolvedValue([
@@ -264,7 +266,7 @@ describe("issue-refiner", () => {
   });
 
   it("processes issues with no body", async () => {
-    const issue = mockIssue({ body: "" });
+    const issue = mockIssue({ body: "", labels: [{ name: "Needs Refinement" }] });
     mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
 
     await run([repo]);
@@ -315,7 +317,7 @@ describe("issue-refiner", () => {
   });
 
   it("regular issue — does not auto-add Refined label", async () => {
-    const issue = mockIssue({ body: "Test issue body" });
+    const issue = mockIssue({ body: "Test issue body", labels: [{ name: "Needs Refinement" }] });
     mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
 
     await run([repo]);
@@ -383,6 +385,26 @@ describe("issue-refiner", () => {
 
     expect(mockClaude.createWorktree).not.toHaveBeenCalled();
     expect(mockGh.commentOnIssue).not.toHaveBeenCalled();
+  });
+
+  it("skips issues without Needs Refinement label", async () => {
+    const issue = mockIssue({ body: "Test issue body", labels: [] });
+    mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
+
+    await run([repo]);
+
+    expect(mockClaude.createWorktree).not.toHaveBeenCalled();
+    expect(mockGh.commentOnIssue).not.toHaveBeenCalled();
+  });
+
+  it("removes Needs Refinement label after posting plan", async () => {
+    const issue = mockIssue({ body: "Test issue body", labels: [{ name: "Needs Refinement" }] });
+    mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
+
+    await run([repo]);
+
+    expect(mockGh.removeLabel).toHaveBeenCalledWith(repo.fullName, issue.number, "Needs Refinement");
+    expect(mockGh.addLabel).toHaveBeenCalledWith(repo.fullName, issue.number, "Ready");
   });
 
   it("skips [yeti-error] issues without investigation report", async () => {

--- a/src/jobs/issue-refiner.ts
+++ b/src/jobs/issue-refiner.ts
@@ -172,6 +172,7 @@ async function processIssue(repo: Repo, issue: gh.Issue): Promise<void> {
     }
 
     await gh.addLabel(fullName, issue.number, LABELS.ready);
+    await gh.removeLabel(fullName, issue.number, LABELS.needsRefinement);
 
     if (isCiUnrelatedIssue(issue)) {
       await gh.addLabel(fullName, issue.number, LABELS.refined);
@@ -396,7 +397,12 @@ export async function run(repos: Repo[]): Promise<void> {
         );
 
         if (lastPlanIdx === -1) {
-          // No plan comment exists — produce a new plan
+          // No plan comment exists — require Needs Refinement label for new plans
+          // (exempt ci-unrelated and yeti-error issues — machine-generated with well-defined workflows)
+          if (!isCiUnrelatedIssue(issue) && extractFingerprint(issue.title) === null &&
+              !issue.labels.some((l) => l.name === LABELS.needsRefinement)) {
+            continue;
+          }
           gh.populateQueueCache("needs-refinement", repo.fullName, { number: issue.number, title: issue.title, type: "issue", updatedAt: issue.updatedAt, priority: gh.hasPriorityLabel(issue.labels) });
           tasks.push(
             processIssue(repo, issue).catch((err) =>

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -72,9 +72,9 @@ Claude processes, and close the database.
 
 **`config.ts`** — Loads configuration in priority order: environment variables >
 `~/.yeti/config.json` > hardcoded defaults. Exports `LABELS` (`refined`,
-`ready`, `priority`, `inReview`), `LABEL_SPECS` (synced to all repos by
-repo-standards — includes colors and descriptions for all four labels),
-`LEGACY_LABELS` (set of old labels cleaned up as stale, including
+`ready`, `priority`, `inReview`, `needsRefinement`), `LABEL_SPECS` (synced to
+all repos by repo-standards — includes colors and descriptions for all five
+labels), `LEGACY_LABELS` (set of old labels cleaned up as stale, including
 `yeti-mergeable` and `yeti-error`), `INTERVALS`, `SCHEDULES`, `ENABLED_JOBS`,
 and connection strings. `WORK_DIR` is always `~/.yeti`. Jobs must be listed in
 `ENABLED_JOBS` (the `enabledJobs` config field) to be registered with the
@@ -243,7 +243,7 @@ See [Jobs](jobs.md) for detailed behavior of each.
 
 | Job | Trigger | Interval | Summary |
 |-----|---------|----------|---------|
-| `issue-refiner` | Open issues without plan comment | 5 min | Discovers issues via comment analysis, posts implementation plans, refines plans based on unreacted human feedback, responds to follow-up questions on issues with open PRs |
+| `issue-refiner` | Issues labelled `Needs Refinement` | 5 min | Posts implementation plans for issues with `Needs Refinement` label (exempt: `[ci-unrelated]` and `[yeti-error]` issues), refines plans based on unreacted human feedback, responds to follow-up questions on issues with open PRs |
 | `issue-worker` | Label `Refined` | 5 min | Implements the issue, creates a PR |
 | `ci-fixer` | Any open PR with failing checks | 10 min | Resolves merge conflicts, fixes CI failures |
 | `review-addresser` | Yeti PRs with unreacted review comments | 5 min | Fetches unresolved review comments, pushes fix commits, reacts with thumbsup to track addressed comments |
@@ -259,16 +259,17 @@ See [Jobs](jobs.md) for detailed behavior of each.
 ### Content-Based State Machine
 
 Issues and PRs are discovered by analysing comments, reactions, and PR state —
-not labels. Four labels are used:
+not labels. Five labels are used:
 
-- `Refined` — trigger for issue-worker (only label that drives a state transition)
+- `Needs Refinement` — trigger for issue-refiner (requests an AI-generated implementation plan)
+- `Refined` — trigger for issue-worker (requests implementation of the plan)
 - `Ready` — informational, signals "Yeti is done, your turn"
 - `In Review` — informational, signals an issue has an open PR under review
 - `Priority` — high-priority items processed first in all Yeti queues
 
 ```
 Issues:
-  No plan comment        →  (refiner posts plan)         →  Ready label added
+  Needs Refinement label →  (refiner posts plan)         →  Needs Refinement removed, Ready added
   Unreacted feedback     →  (refiner refines plan)       →  Ready label re-added
   Open PR + follow-up Q  →  (refiner posts response)     →  👍 reactions added (no label changes)
   Refined label          →  (worker creates PR)          →  Refined removed, Ready removed, In Review added


### PR DESCRIPTION
## Summary

The issue-refiner job was posting implementation plans on all open issues, but the README documented it as only triggering on issues labelled `Needs Refinement`. This PR fixes the issue-refiner to match the documented behavior: only issues with the `Needs Refinement` label receive a new plan (machine-generated `[ci-unrelated]` and `[yeti-error]` issues are exempt). After posting a plan, the label is removed and replaced with `Ready`.

## Changes

- Added `needsRefinement` to `LABELS` in config and moved `"Needs Refinement"` from `LEGACY_LABELS` to `LABEL_SPECS` so it is synced to repos
- Gated new plan generation in `issue-refiner.ts` on the `Needs Refinement` label (with exemptions for `[ci-unrelated]` and `[yeti-error]` issues)
- Added `removeLabel` call after posting a plan to remove `Needs Refinement` once processing completes
- Updated tests to include the label on issues that should be processed, and added tests for skipping unlabelled issues and label removal
- Updated documentation (README, CLAUDE.md, OVERVIEW.md) to reflect the five-label model and the new trigger behavior

Closes #37