### PR TITLE
fix: resolve #45 — recent command

### DIFF
--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -24,6 +24,7 @@ import {
   getTasksByRunId,
   getWorkItemsForRuns,
   getRecentWorkItems,
+  getRecentActions,
   searchRunsByItem,
   insertJobRun,
   completeJobRun,
@@ -601,5 +602,125 @@ describe("getRecentWorkItems", () => {
   it("returns empty array when no tasks exist", () => {
     const items = getRecentWorkItems();
     expect(items).toHaveLength(0);
+  });
+});
+
+describe("getRecentActions", () => {
+  beforeEach(() => {
+    initDb();
+  });
+
+  afterEach(() => {
+    setRunIdProvider(() => undefined);
+    closeDb();
+  });
+
+  it("returns empty array when no tasks exist", () => {
+    const actions = getRecentActions();
+    expect(actions).toHaveLength(0);
+  });
+
+  it("returns tasks ordered by most recent first", () => {
+    const db = _rawDb();
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, status, started_at, completed_at) VALUES (?, ?, ?, 'completed', datetime('now', '-3 hours'), datetime('now', '-2 hours'))`,
+    ).run("auto-merger", "org/repo", 10);
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, status, started_at, completed_at) VALUES (?, ?, ?, 'completed', datetime('now', '-1 hour'), datetime('now'))`,
+    ).run("auto-merger", "org/repo", 20);
+
+    const actions = getRecentActions();
+    expect(actions).toHaveLength(2);
+    expect(actions[0].item_number).toBe(20);
+    expect(actions[1].item_number).toBe(10);
+  });
+
+  it("respects limit parameter", () => {
+    const db = _rawDb();
+    for (let i = 1; i <= 5; i++) {
+      db.prepare(
+        `INSERT INTO tasks (job_name, repo, item_number, status, started_at, completed_at) VALUES (?, ?, ?, 'completed', datetime('now', '-' || ? || ' hours'), datetime('now'))`,
+      ).run("auto-merger", "org/repo", i, i);
+    }
+
+    const actions = getRecentActions(undefined, 3);
+    expect(actions).toHaveLength(3);
+  });
+
+  it("filters by job name when provided", () => {
+    const db = _rawDb();
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, status, started_at, completed_at) VALUES (?, ?, ?, 'completed', datetime('now'), datetime('now'))`,
+    ).run("auto-merger", "org/repo", 10);
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, status, started_at, completed_at) VALUES (?, ?, ?, 'completed', datetime('now'), datetime('now'))`,
+    ).run("issue-worker", "org/repo", 20);
+
+    const actions = getRecentActions("auto-merger");
+    expect(actions).toHaveLength(1);
+    expect(actions[0].job_name).toBe("auto-merger");
+  });
+
+  it("includes summary from matching log line", () => {
+    const db = _rawDb();
+    insertJobRun("run-1", "auto-merger");
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, run_id, status, started_at, completed_at) VALUES (?, ?, ?, ?, 'completed', datetime('now'), datetime('now'))`,
+    ).run("auto-merger", "org/repo", 51, "run-1");
+    insertJobLog("run-1", "info", "[auto-merger] Merging org/repo#51: Fix auth middleware");
+
+    const actions = getRecentActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0].summary).toBe("[auto-merger] Merging org/repo#51: Fix auth middleware");
+  });
+
+  it("returns null summary when no matching log exists", () => {
+    const db = _rawDb();
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, status, started_at, completed_at) VALUES (?, ?, ?, 'completed', datetime('now'), datetime('now'))`,
+    ).run("auto-merger", "org/repo", 10);
+
+    const actions = getRecentActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0].summary).toBeNull();
+  });
+
+  it("excludes running tasks", () => {
+    const db = _rawDb();
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, status, started_at) VALUES (?, ?, ?, 'running', datetime('now'))`,
+    ).run("auto-merger", "org/repo", 10);
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, status, started_at, completed_at) VALUES (?, ?, ?, 'completed', datetime('now'), datetime('now'))`,
+    ).run("auto-merger", "org/repo", 20);
+
+    const actions = getRecentActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0].item_number).toBe(20);
+  });
+
+  it("excludes tasks with item_number = 0", () => {
+    const db = _rawDb();
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, status, started_at, completed_at) VALUES (?, ?, ?, 'completed', datetime('now'), datetime('now'))`,
+    ).run("doc-maintainer", "org/repo", 0);
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, status, started_at, completed_at) VALUES (?, ?, ?, 'completed', datetime('now'), datetime('now'))`,
+    ).run("auto-merger", "org/repo", 5);
+
+    const actions = getRecentActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0].item_number).toBe(5);
+  });
+
+  it("includes failed tasks", () => {
+    const db = _rawDb();
+    db.prepare(
+      `INSERT INTO tasks (job_name, repo, item_number, status, error, started_at, completed_at) VALUES (?, ?, ?, 'failed', 'timeout', datetime('now'), datetime('now'))`,
+    ).run("issue-worker", "org/repo", 15);
+
+    const actions = getRecentActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0].status).toBe("failed");
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -324,6 +324,40 @@ export function searchRunsByItem(search: string, limit = 50): JobRun[] {
     .all(`%${search}%`, search, limit) as JobRun[];
 }
 
+export interface RecentAction {
+  job_name: string;
+  repo: string;
+  item_number: number;
+  status: string;
+  started_at: string;
+  completed_at: string | null;
+  summary: string | null;
+}
+
+export function getRecentActions(jobFilter?: string, limit = 10): RecentAction[] {
+  const filterClause = jobFilter ? "AND t.job_name = ?" : "";
+  const params: (string | number)[] = [];
+  if (jobFilter) params.push(jobFilter);
+  params.push(limit);
+
+  return getDb()
+    .prepare(`
+      SELECT t.job_name, t.repo, t.item_number, t.status, t.started_at, t.completed_at,
+        (SELECT jl.message FROM job_logs jl
+         WHERE jl.run_id = t.run_id
+         AND jl.level = 'info'
+         AND jl.message LIKE '%#' || t.item_number || '%'
+         ORDER BY jl.id DESC LIMIT 1) as summary
+      FROM tasks t
+      WHERE t.item_number > 0
+        AND t.status IN ('completed', 'failed')
+        ${filterClause}
+      ORDER BY t.started_at DESC
+      LIMIT ?
+    `)
+    .all(...params) as RecentAction[];
+}
+
 export function hasPreviousCiFixerTasks(repo: string, prNumber: number): boolean {
   const row = getDb()
     .prepare(

--- a/src/discord.test.ts
+++ b/src/discord.test.ts
@@ -54,6 +54,10 @@ vi.mock("./log.js", () => ({
   error: vi.fn(),
 }));
 
+vi.mock("./db.js", () => ({
+  getRecentActions: vi.fn().mockReturnValue([]),
+}));
+
 vi.mock("./claude.js", () => ({
   queueStatus: vi.fn().mockReturnValue({ pending: 2, active: 1 }),
   enqueue: vi.fn((fn: () => Promise<string>) => fn()),
@@ -74,6 +78,7 @@ vi.mock("./github.js", () => ({
 
 import { isDiscordConfigured, discordStatus, notify, start, stop, ready } from "./discord.js";
 import * as gh from "./github.js";
+import * as db from "./db.js";
 import { runClaude } from "./claude.js";
 import type { Scheduler } from "./scheduler.js";
 
@@ -485,6 +490,86 @@ describe("start and commands", () => {
       expect(msg.reply).toHaveBeenCalled();
     });
     expect(msg.reply).toHaveBeenCalledWith("Unknown repo: **badrepo**");
+  });
+
+  // ── recent command ──
+
+  it("!yeti recent with no actions shows 'No recent actions'", async () => {
+    vi.mocked(db.getRecentActions).mockReturnValue([]);
+    const scheduler = makeScheduler();
+    await start(scheduler);
+    const msg = makeMessage({ content: "!yeti recent" });
+    mockEventHandlers["messageCreate"](msg);
+    await vi.waitFor(() => {
+      expect(msg.reply).toHaveBeenCalled();
+    });
+    expect(msg.reply).toHaveBeenCalledWith("No recent actions");
+  });
+
+  it("!yeti recent returns formatted output grouped by job", async () => {
+    vi.mocked(db.getRecentActions).mockReturnValue([
+      { job_name: "auto-merger", repo: "org/repo", item_number: 51, status: "completed", started_at: "2026-03-21", completed_at: "2026-03-21", summary: "[auto-merger] Merging org/repo#51: Fix auth" },
+      { job_name: "issue-worker", repo: "org/repo", item_number: 42, status: "completed", started_at: "2026-03-21", completed_at: "2026-03-21", summary: null },
+    ]);
+    const scheduler = makeScheduler();
+    await start(scheduler);
+    const msg = makeMessage({ content: "!yeti recent" });
+    mockEventHandlers["messageCreate"](msg);
+    await vi.waitFor(() => {
+      expect(msg.reply).toHaveBeenCalled();
+    });
+    const reply = msg.reply.mock.calls[0][0] as string;
+    expect(reply).toContain("**auto-merger**");
+    expect(reply).toContain("Merging org/repo#51: Fix auth");
+    expect(reply).not.toContain("[auto-merger]"); // prefix stripped
+    expect(reply).toContain("**issue-worker**");
+    expect(reply).toContain("org/repo#42 (completed)"); // fallback format
+  });
+
+  it("!yeti recent auto-merger passes job filter", async () => {
+    vi.mocked(db.getRecentActions).mockReturnValue([]);
+    const scheduler = makeScheduler();
+    await start(scheduler);
+    const msg = makeMessage({ content: "!yeti recent auto-merger" });
+    mockEventHandlers["messageCreate"](msg);
+    await vi.waitFor(() => {
+      expect(msg.reply).toHaveBeenCalled();
+    });
+    expect(db.getRecentActions).toHaveBeenCalledWith("auto-merger", 10);
+    expect(msg.reply).toHaveBeenCalledWith("No recent actions for **auto-merger**");
+  });
+
+  it("!yeti recent truncates output at 1900 chars", async () => {
+    const longActions = Array.from({ length: 20 }, (_, i) => ({
+      job_name: "auto-merger",
+      repo: "org/repo",
+      item_number: i + 1,
+      status: "completed" as const,
+      started_at: "2026-03-21",
+      completed_at: "2026-03-21",
+      summary: `[auto-merger] Merging org/repo#${i + 1}: ${"A".repeat(100)}`,
+    }));
+    vi.mocked(db.getRecentActions).mockReturnValue(longActions);
+    const scheduler = makeScheduler();
+    await start(scheduler);
+    const msg = makeMessage({ content: "!yeti recent auto-merger" });
+    mockEventHandlers["messageCreate"](msg);
+    await vi.waitFor(() => {
+      expect(msg.reply).toHaveBeenCalled();
+    });
+    const reply = msg.reply.mock.calls[0][0] as string;
+    expect(reply.length).toBeLessThanOrEqual(1903); // 1900 + "..."
+  });
+
+  it("help text includes the recent command", async () => {
+    const scheduler = makeScheduler();
+    await start(scheduler);
+    const msg = makeMessage({ content: "!yeti help" });
+    mockEventHandlers["messageCreate"](msg);
+    await vi.waitFor(() => {
+      expect(msg.reply).toHaveBeenCalled();
+    });
+    expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("!yeti recent"));
   });
 
   it("sets lastResult to ok after successful ready event", async () => {

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -2,6 +2,7 @@ import { Client, GatewayIntentBits, type Message, type TextChannel } from "disco
 import { DISCORD_BOT_TOKEN, DISCORD_CHANNEL_ID, DISCORD_ALLOWED_USERS, GITHUB_OWNERS } from "./config.js";
 import * as log from "./log.js";
 import * as gh from "./github.js";
+import * as db from "./db.js";
 import { queueStatus, enqueue, runClaude } from "./claude.js";
 import type { Scheduler } from "./scheduler.js";
 
@@ -287,6 +288,45 @@ async function handleCommand(command: string, args: string[], message: Message):
       break;
     }
 
+    case "recent": {
+      const jobFilter = args[0] || undefined;
+      const perJobLimit = jobFilter ? 10 : 3;
+      const totalLimit = jobFilter ? 10 : 30;
+      const actions = db.getRecentActions(jobFilter, totalLimit);
+
+      if (actions.length === 0) {
+        await message.reply(jobFilter ? `No recent actions for **${jobFilter}**` : "No recent actions");
+        break;
+      }
+
+      const grouped = new Map<string, typeof actions>();
+      for (const action of actions) {
+        const list = grouped.get(action.job_name) ?? [];
+        if (list.length < perJobLimit) list.push(action);
+        grouped.set(action.job_name, list);
+      }
+
+      const sections: string[] = [];
+      for (const [jobName, items] of grouped) {
+        const lines = items.map((a) => {
+          if (a.summary) {
+            const cleaned = a.summary.replace(/^\[.*?\]\s*/, "");
+            return `• ${cleaned}`;
+          }
+          return `• ${a.repo}#${a.item_number} (${a.status})`;
+        });
+        sections.push(`**${jobName}** (${items.length} recent)\n${lines.join("\n")}`);
+      }
+
+      let output = sections.join("\n\n");
+      if (!jobFilter && actions.length > [...grouped.values()].reduce((s, v) => s + v.length, 0)) {
+        output += "\n\n_Use `!yeti recent <job>` for more_";
+      }
+      if (output.length > 1900) output = output.slice(0, 1900) + "...";
+      await message.reply(output);
+      break;
+    }
+
     case "help": {
       await message.reply(
         "**Yeti Commands:**\n" +
@@ -295,6 +335,7 @@ async function handleCommand(command: string, args: string[], message: Message):
         "`!yeti trigger <job>` — trigger a job\n" +
         "`!yeti pause <job>` — pause a job\n" +
         "`!yeti resume <job>` — resume a job\n" +
+        "`!yeti recent [job]` — show recent actions\n" +
         "`!yeti issue <repo> <title>` — create a GitHub issue\n" +
         "`!yeti look <repo>#<number>` — summarize an issue/PR\n" +
         "`!yeti assign <repo>#<number>` — label issue as Refined\n" +


### PR DESCRIPTION
## Summary

Add a `!yeti recent` command to the Discord bot that shows the last actions performed by each job, giving quick visibility into what Yeti has been doing. When called without arguments it shows the 3 most recent actions per job; when called with a specific job name (e.g. `!yeti recent auto-merger`) it shows up to 10 actions for that job.

## Changes

- Added `getRecentActions()` query in `src/db.ts` that fetches completed/failed tasks with an optional job filter, joining against `job_logs` to pull a human-readable summary line for each action
- Added `recent` command handler in `src/discord.ts` that groups actions by job name, strips redundant `[job-name]` prefixes from summaries, and truncates output to fit Discord's message limit
- Updated the `!yeti help` output to include the new command
- Added comprehensive tests for both the DB query and the Discord command

Closes #45