### PR TITLE
fix: resolve #44 — [yeti-error] auto-merger:process-pr

### DIFF
--- a/src/jobs/auto-merger.test.ts
+++ b/src/jobs/auto-merger.test.ts
@@ -27,6 +27,7 @@ const { mockGh } = vi.hoisted(() => ({
     mergePR: vi.fn(),
     removeLabel: vi.fn(),
     getPRChangedFiles: vi.fn(),
+    getPRMergeableState: vi.fn(),
     isRateLimited: vi.fn().mockReturnValue(false),
     isItemSkipped: vi.fn().mockReturnValue(false),
     hasPriorityLabel: vi.fn().mockReturnValue(false),
@@ -51,6 +52,7 @@ describe("auto-merger", () => {
     mockGh.mergePR.mockResolvedValue(undefined);
     mockGh.removeLabel.mockResolvedValue(undefined);
     mockGh.getPRChangedFiles.mockResolvedValue([]);
+    mockGh.getPRMergeableState.mockResolvedValue("MERGEABLE");
   });
 
   it("merges dependabot PR when checks pass", async () => {
@@ -263,5 +265,43 @@ describe("auto-merger", () => {
     await run([repo]);
 
     expect(mockGh.mergePR).not.toHaveBeenCalled();
+  });
+
+  it("skips PR with merge conflicts", async () => {
+    const pr = mockPR({ author: { login: "dependabot[bot]" } });
+    mockGh.listPRs.mockResolvedValue([pr]);
+    mockGh.getPRCheckStatus.mockResolvedValue("passing");
+    mockGh.getPRMergeableState.mockResolvedValue("CONFLICTING");
+
+    await run([repo]);
+
+    expect(mockGh.mergePR).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      `[auto-merger] ${repo.fullName}#${pr.number} has merge conflicts, skipping`,
+    );
+  });
+
+  it("skips PR in UNKNOWN mergeable state", async () => {
+    const pr = mockPR({ author: { login: "dependabot[bot]" } });
+    mockGh.listPRs.mockResolvedValue([pr]);
+    mockGh.getPRCheckStatus.mockResolvedValue("passing");
+    mockGh.getPRMergeableState.mockResolvedValue("UNKNOWN");
+
+    await run([repo]);
+
+    expect(mockGh.mergePR).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("checks mergeable state before merging", async () => {
+    const pr = mockPR({ author: { login: "dependabot[bot]" } });
+    mockGh.listPRs.mockResolvedValue([pr]);
+    mockGh.getPRCheckStatus.mockResolvedValue("passing");
+    mockGh.getPRMergeableState.mockResolvedValue("MERGEABLE");
+
+    await run([repo]);
+
+    expect(mockGh.getPRMergeableState).toHaveBeenCalledWith(repo.fullName, pr.number);
+    expect(mockGh.mergePR).toHaveBeenCalledWith(repo.fullName, pr.number);
   });
 });

--- a/src/jobs/auto-merger.ts
+++ b/src/jobs/auto-merger.ts
@@ -48,6 +48,14 @@ export async function run(repos: Repo[]): Promise<void> {
             continue;
           }
 
+          const mergeState = await gh.getPRMergeableState(repo.fullName, pr.number);
+          if (mergeState !== "MERGEABLE") {
+            if (mergeState === "CONFLICTING") {
+              log.warn(`[auto-merger] ${repo.fullName}#${pr.number} has merge conflicts, skipping`);
+            }
+            continue;
+          }
+
           gh.populateQueueCache("auto-mergeable", repo.fullName, { number: pr.number, title: pr.title, type: "pr", updatedAt: pr.updatedAt, priority: gh.hasPriorityLabel(pr.labels) });
           log.info(`[auto-merger] Merging ${repo.fullName}#${pr.number}: ${pr.title}`);
           await gh.mergePR(repo.fullName, pr.number);


### PR DESCRIPTION
## Summary

The auto-merger job was failing with "Pull Request is not mergeable" errors when attempting to merge PRs that had merge conflicts or were in an unmergeable state (issue #44). This adds a `getPRMergeableState` check before calling `gh pr merge`, skipping PRs that are `CONFLICTING` (with a warning) or in an `UNKNOWN` state (silently, as GitHub may still be computing mergeability).

## Changes

- Check PR mergeable state via `getPRMergeableState` before attempting to merge
- Skip PRs with `CONFLICTING` state and log a warning about merge conflicts
- Silently skip PRs in `UNKNOWN` state (GitHub hasn't determined mergeability yet)
- Add tests covering conflict, unknown, and mergeable scenarios

Closes #44