### PR TITLE
fix: don't mark plan as reviewed when AI output is empty

### DIFF
--- a/src/jobs/plan-reviewer.test.ts
+++ b/src/jobs/plan-reviewer.test.ts
@@ -198,4 +198,27 @@ describe("plan-reviewer", () => {
       { backend: "copilot" },
     );
   });
+
+  it("does not mark as processed when review output is empty", async () => {
+    const issue = mockIssue({
+      body: "Test issue body",
+      labels: [{ name: "Needs Plan Review" }],
+    });
+    mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
+    mockGh.getIssueComments.mockResolvedValue([
+      { id: 501, body: planCommentBody, login: "yeti-bot" },
+    ]);
+    mockGh.getCommentReactions.mockResolvedValue([]);
+    mockClaude.runAI.mockResolvedValue("");
+
+    await run([repo]);
+
+    // Should NOT react, remove label, or post comment
+    expect(mockGh.addReaction).not.toHaveBeenCalled();
+    expect(mockGh.removeLabel).not.toHaveBeenCalled();
+    expect(mockGh.commentOnIssue).not.toHaveBeenCalled();
+
+    // Should record failure so it retries
+    expect(mockDb.recordTaskFailed).toHaveBeenCalledWith(1, "Empty review output");
+  });
 });

--- a/src/jobs/plan-reviewer.ts
+++ b/src/jobs/plan-reviewer.ts
@@ -58,12 +58,14 @@ async function processIssue(repo: Repo, issue: gh.Issue, planComment: gh.IssueCo
       gh.hasPriorityLabel(issue.labels),
     );
 
-    if (reviewOutput.trim()) {
-      await gh.commentOnIssue(fullName, issue.number, `${REVIEW_HEADER}\n\n${reviewOutput}`);
-      log.info(`[plan-reviewer] Posted review for ${fullName}#${issue.number}`);
-    } else {
-      log.warn(`[plan-reviewer] Empty review output for ${fullName}#${issue.number}`);
+    if (!reviewOutput.trim()) {
+      log.warn(`[plan-reviewer] Empty review output for ${fullName}#${issue.number} — will retry next cycle`);
+      db.recordTaskFailed(taskId, "Empty review output");
+      return;
     }
+
+    await gh.commentOnIssue(fullName, issue.number, `${REVIEW_HEADER}\n\n${reviewOutput}`);
+    log.info(`[plan-reviewer] Posted review for ${fullName}#${issue.number}`);
 
     // Mark plan comment as processed
     await gh.addReaction(fullName, planComment.id, "+1");


### PR DESCRIPTION
## Summary

- When the AI backend returns empty output (model error, exit code 1), plan-reviewer was still adding a thumbsup reaction and removing the `Needs Plan Review` label, causing the issue to silently skip future review cycles
- Now early-returns with a task failure so the label and reaction are preserved and it retries next cycle

## Test plan

- [x] New test: "does not mark as processed when review output is empty"
- [x] All 1416 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)