### PR TITLE
docs: clarify plan-reviewer human-in-the-loop workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,9 @@ Yeti is a self-hosted GitHub automation daemon that polls repositories on timers
 
 ### Jobs (`src/jobs/`)
 
-Each job exports a `run()` function. Jobs discover work via comment analysis, reactions, labels, and PR state — not solely labels. Six labels exist: `Needs Refinement` (trigger for issue-refiner), `Needs Plan Review` (trigger for plan-reviewer), `Refined` (trigger for issue-worker), `Ready` (informational), `In Review` (informational), `Priority` (queue ordering). Processed items are tracked via thumbsup reactions on comments.
+Each job exports a `run()` function. Jobs discover work via comment analysis, reactions, labels, and PR state — not solely labels. Six labels exist: `Needs Refinement` (trigger for issue-refiner), `Needs Plan Review` (trigger for plan-reviewer), `Refined` (trigger for issue-worker), `Ready` (human decision needed), `In Review` (informational), `Priority` (queue ordering). Processed items are tracked via thumbsup reactions on comments.
+
+When plan-reviewer is enabled, the workflow is human-in-the-loop: issue-refiner produces a plan → plan-reviewer critiques it → both land on the issue as comments with `Ready` label → a human reads the plan and critique, then either adds `Refined` to approve or posts feedback to trigger another refinement cycle. The adversarial review is for the human, not for automatic AI-to-AI refinement.
 
 Jobs must be listed in the `enabledJobs` config array to run. An empty or missing `enabledJobs` means no jobs start.
 

--- a/README.md
+++ b/README.md
@@ -194,11 +194,16 @@ All other PRs (non-Yeti, non-Dependabot) are ignored by auto-merger.
 Issues move through labels to track state:
 
 ```
-(new issue)         →  (refiner runs)  →  Plan comment posted
-                    →  (reviewer runs) →  Plan reviewed         [if plan-reviewer enabled]
+(new issue)         →  (refiner runs)  →  Plan comment posted  →  Ready
+                    →  (reviewer runs) →  Plan reviewed         →  Ready  [if plan-reviewer enabled]
+                    →  Human reviews plan + critique, then either:
+                         • Adds "Refined" to approve implementation
+                         • Posts feedback → refiner refines → reviewer re-reviews
 Refined             →  (worker runs)   →  PR created  →  In Review
 In Review + LGTM    →  (merger runs)   →  PR merged
 ```
+
+The `Ready` label always means "waiting for a human decision." When plan-reviewer is enabled, the human sees both the plan and an adversarial critique before deciding whether to proceed. The review is **for the human**, not for automatic refinement — this prevents infinite back-and-forth between AIs.
 
 The `Priority` label is used for queue ordering across all jobs but does not trigger any job on its own.
 

--- a/yeti/jobs.md
+++ b/yeti/jobs.md
@@ -97,13 +97,23 @@ Copilot (or Gemini via Copilot) critiques it.
 - Reacts 👍 to the plan comment (marks as processed)
 - Removes `Needs Plan Review` label, adds `Ready` label
 
-### Interaction with issue-refiner
+### Human-in-the-loop workflow
 
-When `plan-reviewer` is in `enabledJobs`, issue-refiner adds `Needs Plan Review`
-instead of `Ready` after producing or refining a plan. After plan-reviewer
-completes its review, it transitions the issue to `Ready`. If a human posts
-feedback on a reviewed plan, issue-refiner picks it up, refines, and the
-conditional label logic routes it through plan-reviewer again.
+The adversarial review is **for the human**, not for automatic refinement.
+When plan-reviewer is enabled, the full lifecycle is:
+
+1. **issue-refiner** produces or refines a plan → adds `Needs Plan Review`
+2. **plan-reviewer** critiques the plan via a different AI → posts `## Plan Review` → adds `Ready`
+3. **Human** reads both the plan and the adversarial critique, then decides:
+   - **Plan is good** → add `Refined` label to start implementation
+   - **Review raised valid concerns** → post feedback comments on the issue →
+     issue-refiner detects unreacted comments, refines the plan, and routes it
+     back through plan-reviewer for another review cycle
+
+The review does **not** automatically feed back into refinement. This is
+intentional — without a human gatekeeper, the two AIs could enter an infinite
+loop of critiquing and revising each other's plans. The `Ready` label always
+means "a human needs to look at this."
 
 ## issue-worker
 


### PR DESCRIPTION
## Summary

- Clarify that the adversarial plan review is **for the human**, not for automatic AI-to-AI refinement
- Update README label workflow diagram to show the full lifecycle including human decision point
- Update jobs.md plan-reviewer section with explicit "Human-in-the-loop workflow" subsection
- Update CLAUDE.md architecture notes to describe the workflow

## Changes

- **README.md** — Expanded label workflow diagram showing Ready → human decides → Refined or feedback loop
- **yeti/jobs.md** — Replaced "Interaction with issue-refiner" with detailed "Human-in-the-loop workflow" section
- **CLAUDE.md** — Added workflow summary to Jobs section

🤖 Generated with [Claude Code](https://claude.com/claude-code)