### PR TITLE
fix: issue-refiner re-plans when Needs Refinement label is re-added

### DIFF
--- a/src/jobs/issue-refiner.test.ts
+++ b/src/jobs/issue-refiner.test.ts
@@ -426,4 +426,28 @@ describe("issue-refiner", () => {
     expect(mockClaude.createWorktree).not.toHaveBeenCalled();
     expect(mockGh.commentOnIssue).not.toHaveBeenCalled();
   });
+
+  it("re-plans when Needs Refinement label is present even if a plan already exists", async () => {
+    const issue = mockIssue({
+      body: "Add dark mode",
+      labels: [{ name: "Needs Refinement" }],
+    });
+    mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
+    mockGh.getOpenPRForIssue.mockResolvedValue(null);
+    mockGh.getIssueComments.mockResolvedValue([
+      { id: 100, body: "<!-- yeti-automated -->\n## Implementation Plan\n\nOld plan here", login: "yeti-bot" },
+      { id: 101, body: "<!-- yeti-automated -->\n## Plan Review\n\nSome critique", login: "yeti-bot" },
+    ]);
+    mockClaude.runClaude.mockResolvedValue("New fresh plan");
+
+    await run([repo]);
+
+    // Should create a worktree and produce a new plan
+    expect(mockClaude.createWorktree).toHaveBeenCalled();
+    expect(mockGh.commentOnIssue).toHaveBeenCalledWith(
+      repo.fullName,
+      issue.number,
+      expect.stringContaining("## Implementation Plan"),
+    );
+  });
 });

--- a/src/jobs/issue-refiner.ts
+++ b/src/jobs/issue-refiner.ts
@@ -417,6 +417,14 @@ export async function run(repos: Repo[]): Promise<void> {
               reportError("issue-refiner:process-issue", `${repo.fullName}#${issue.number}`, err),
             ),
           );
+        } else if (issue.labels.some((l) => l.name === LABELS.needsRefinement)) {
+          // Plan exists but Needs Refinement label was re-added — produce a fresh plan
+          gh.populateQueueCache("needs-refinement", repo.fullName, { number: issue.number, title: issue.title, type: "issue", updatedAt: issue.updatedAt, priority: gh.hasPriorityLabel(issue.labels) });
+          tasks.push(
+            processIssue(repo, issue).catch((err) =>
+              reportError("issue-refiner:process-issue", `${repo.fullName}#${issue.number}`, err),
+            ),
+          );
         } else {
           // Plan exists — check for unreacted human comments after the plan
           const commentsAfterPlan = comments.slice(lastPlanIdx + 1);


### PR DESCRIPTION
## Summary

- When a plan comment already exists but the issue still has `Needs Refinement` (e.g. after a failed plan-reviewer run where labels were manually reset), issue-refiner was silently classifying it as "ready" instead of producing a fresh plan
- Root cause: the existing plan caused issue-refiner to skip to the "check for unreacted comments" path, where the only post-plan comment was a Yeti-authored `## Plan Review` (filtered out), resulting in "all feedback addressed" → no action
- Fix: check for `Needs Refinement` label before the unreacted-comments path — if present, treat it as a request for a fresh plan

## Test plan

- [x] New test: "re-plans when Needs Refinement label is present even if a plan already exists"
- [x] All 1418 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)