### PR TITLE
docs: clarify yeti/ directory is for AI context, not public docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **update documentation** After any change to source code, update relevant documentation in CLAUDE.md, README.md and the yeti/ folder. A task is not complete without reviewing and updating relevant documentation.
 
+**yeti/ directory** The `yeti/` directory contains documentation written for AI consumption and context enhancement, not primarily for humans. Jobs like `doc-maintainer` and `issue-worker` instruct the AI to read `yeti/OVERVIEW.md` and related files for codebase context before performing tasks. Write content in this directory to be maximally useful to an AI agent understanding the codebase — detailed architecture, patterns, and decision rationale rather than user-facing guides.
+
 ## Build & Run Commands
 
 ```sh


### PR DESCRIPTION
## Summary

- Add note to CLAUDE.md explaining that the `yeti/` directory is for AI consumption and context enhancement, not primarily for human-facing documentation
- Guides contributors to write content optimized for AI agents understanding the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)