### PR TITLE
fix: remove local-clone guard so jobs process newly-added repos

### DIFF
--- a/src/jobs/doc-maintainer.test.ts
+++ b/src/jobs/doc-maintainer.test.ts
@@ -89,13 +89,13 @@ describe("doc-maintainer", () => {
     mockPlanParser.findPlanComment.mockReturnValue(null);
   });
 
-  it("skips repo without local clone", async () => {
+  it("processes repo even without local clone", async () => {
     mockFs.existsSync.mockReturnValue(false);
 
     await run([repo]);
 
-    expect(mockGh.listPRs).not.toHaveBeenCalled();
-    expect(mockClaude.createWorktree).not.toHaveBeenCalled();
+    expect(mockGh.listPRs).toHaveBeenCalledWith(repo.fullName);
+    expect(mockClaude.createWorktree).toHaveBeenCalled();
   });
 
   it("skips repo when open docs PR already exists", async () => {

--- a/src/jobs/doc-maintainer.ts
+++ b/src/jobs/doc-maintainer.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { WORK_DIR, type Repo } from "../config.js";
+import { type Repo } from "../config.js";
 import * as gh from "../github.js";
 import * as claude from "../claude.js";
 import * as log from "../log.js";
@@ -58,10 +58,6 @@ function buildDocPrompt(fullName: string, planCount = 0): string {
 
 async function processRepo(repo: Repo): Promise<void> {
   const fullName = repo.fullName;
-
-  // Step 0: Skip repos yeti isn't working with
-  const repoDir = path.join(WORK_DIR, "repos", repo.owner, repo.name);
-  if (!fs.existsSync(repoDir)) return;
 
   // Step 1: Check for existing open docs PR
   const prs = await gh.listPRs(fullName);

--- a/src/jobs/improvement-identifier.test.ts
+++ b/src/jobs/improvement-identifier.test.ts
@@ -81,13 +81,13 @@ describe("improvement-identifier", () => {
     mockClaude.pushBranch.mockResolvedValue(undefined);
   });
 
-  it("skips repo without local clone", async () => {
+  it("processes repo even without local clone", async () => {
     mockFs.existsSync.mockReturnValue(false);
 
     await run([repo]);
 
-    expect(mockGh.listOpenIssues).not.toHaveBeenCalled();
-    expect(mockClaude.createWorktree).not.toHaveBeenCalled();
+    expect(mockGh.listOpenIssues).toHaveBeenCalled();
+    expect(mockClaude.createWorktree).toHaveBeenCalled();
   });
 
   it("skips repo when open improvement PRs exist", async () => {

--- a/src/jobs/improvement-identifier.ts
+++ b/src/jobs/improvement-identifier.ts
@@ -1,6 +1,4 @@
-import fs from "node:fs";
-import path from "node:path";
-import { WORK_DIR, type Repo } from "../config.js";
+import { type Repo } from "../config.js";
 import * as gh from "../github.js";
 import * as claude from "../claude.js";
 import * as log from "../log.js";
@@ -122,10 +120,6 @@ const FOOTER = "\n\n---\n*Automated improvement by yeti improvement-identifier*"
 
 async function processRepo(repo: Repo): Promise<void> {
   const fullName = repo.fullName;
-
-  // Skip repos without local clones
-  const repoDir = path.join(WORK_DIR, "repos", repo.owner, repo.name);
-  if (!fs.existsSync(repoDir)) return;
 
   // Fetch open issue titles and PR titles for dedup context
   const openIssues = await gh.listOpenIssues(fullName);

--- a/src/jobs/repo-standards.test.ts
+++ b/src/jobs/repo-standards.test.ts
@@ -56,13 +56,13 @@ describe("repo-standards", () => {
     mockGh.deleteStaleLabels.mockResolvedValue(undefined);
   });
 
-  it("skips repos without local clone", async () => {
+  it("processes repos even without local clone", async () => {
     mockFs.existsSync.mockReturnValue(false);
 
     await run([repo]);
 
-    expect(mockGh.ensureAllLabels).not.toHaveBeenCalled();
-    expect(mockGh.deleteStaleLabels).not.toHaveBeenCalled();
+    expect(mockGh.ensureAllLabels).toHaveBeenCalledWith(repo.fullName);
+    expect(mockGh.deleteStaleLabels).toHaveBeenCalledWith(repo.fullName, LEGACY_LABELS);
   });
 
   it("syncs labels and deletes stale labels for repos with local clone", async () => {

--- a/src/jobs/repo-standards.ts
+++ b/src/jobs/repo-standards.ts
@@ -1,14 +1,9 @@
-import fs from "node:fs";
-import path from "node:path";
-import { WORK_DIR, LEGACY_LABELS, type Repo } from "../config.js";
+import { LEGACY_LABELS, type Repo } from "../config.js";
 import * as gh from "../github.js";
 import * as log from "../log.js";
 import { reportError } from "../error-reporter.js";
 
 async function processRepo(repo: Repo): Promise<void> {
-  const repoDir = path.join(WORK_DIR, "repos", repo.owner, repo.name);
-  if (!fs.existsSync(repoDir)) return;
-
   log.info(`[repo-standards] Syncing labels for ${repo.fullName}`);
   await gh.ensureAllLabels(repo.fullName);
   await gh.deleteStaleLabels(repo.fullName, LEGACY_LABELS);


### PR DESCRIPTION
## Summary
- **repo-standards**, **doc-maintainer**, and **improvement-identifier** all had an `fs.existsSync(repoDir)` guard that silently skipped repos without an existing local clone in `~/.yeti/repos/`
- Newly-added repos were invisible to these jobs until another job (like ci-fixer or issue-worker) happened to clone them first
- `repo-standards` only makes GitHub API calls — no local clone needed at all
- `doc-maintainer` and `improvement-identifier` already call `createWorktree()` → `ensureClone()`, which handles cloning automatically

## Test plan
- [x] Updated 3 test files to assert repos are processed regardless of local clone state
- [x] All 1417 tests pass
- [x] TypeScript build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)