### PR TITLE
docs: update documentation for yeti

### DIFF
--- a/yeti/jobs.md
+++ b/yeti/jobs.md
@@ -300,8 +300,6 @@ For each canonical (non-duplicate) issue:
 **Schedule**: Runs at hour configured by `schedules.docMaintainerHour`
 (default: 1 AM local time)
 
-- Only processes repos that Yeti has previously cloned (checks for
-  `~/.yeti/repos/<owner>/<repo>`)
 - Skips if an open `yeti/docs-*` PR already exists for the repo
 - Skips if HEAD matches the last `[doc-maintainer]` commit (no new code
   changes to document)
@@ -362,7 +360,7 @@ For each PR:
 **Schedule**: Runs at hour configured by `schedules.repoStandardsHour`
 (default: 2 AM local time)
 
-Only processes repos that Yeti has previously cloned. For each repo:
+For each repo:
 
 - **Syncs label definitions** — calls `ensureAllLabels()` to create/update
   all labels defined in `LABEL_SPECS` (from `config.ts`) with correct colors
@@ -382,7 +380,7 @@ via the `gh` CLI.
 **Schedule**: Runs at hour configured by `schedules.improvementIdentifierHour`
 (default: 3 AM local time)
 
-Only processes repos that Yeti has previously cloned. Skips repos that
+Skips repos that
 already have open `yeti/improve-*` PRs (prevents pile-up when previous
 improvements haven't been merged). Repos are processed concurrently.
 Two-phase approach per repo:


### PR DESCRIPTION
## Summary

Updated job documentation to reflect the removal of the local-clone guard from scheduled jobs. After PR #60 removed the check that restricted jobs to only previously-cloned repos, the documentation still referenced this behavior. These changes bring the docs in line with the current code.

## Changes

- **doc-maintainer**: Removed note that it only processes repos Yeti has previously cloned
- **repo-standards**: Removed local-clone prerequisite from job description
- **improvement-identifier**: Removed local-clone prerequisite from job description