### PR TITLE
docs: add MkDocs documentation site

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "frostyard-ai": {
+      "source": {
+        "source": "github",
+        "repo": "frostyard/frostyard-ai"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "frostyard-dev@frostyard-ai": true,
+    "frostyard-os@frostyard-ai": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.env
 config.json
 .worktrees/
+_site/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,88 @@
+site_name: Yeti
+site_description: Self-hosted GitHub automation that plans, implements, and maintains your repos — so you can stay in the cold zone.
+site_url: ""
+docs_dir: site
+site_dir: _site
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue grey
+      accent: light blue
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue grey
+      accent: light blue
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - tables
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Configuration: getting-started/configuration.md
+      - Quickstart: getting-started/quickstart.md
+  - Usage:
+      - Daily Workflow: usage/daily-workflow.md
+      - Dashboard: usage/dashboard.md
+      - Discord Bot: usage/discord.md
+      - Queue Management: usage/queue-management.md
+      - Optimization: usage/optimization.md
+      - Troubleshooting: usage/troubleshooting.md
+  - Contributing: contributing.md
+  - Reference:
+      - Configuration: reference/configuration.md
+      - Labels: reference/labels.md
+      - Issue Lifecycle: reference/workflow.md
+      - HTTP API: reference/api.md
+      - Jobs:
+          - Overview: reference/jobs/index.md
+          - issue-refiner: reference/jobs/issue-refiner.md
+          - plan-reviewer: reference/jobs/plan-reviewer.md
+          - issue-worker: reference/jobs/issue-worker.md
+          - ci-fixer: reference/jobs/ci-fixer.md
+          - auto-merger: reference/jobs/auto-merger.md
+          - review-addresser: reference/jobs/review-addresser.md
+          - doc-maintainer: reference/jobs/doc-maintainer.md
+          - improvement-identifier: reference/jobs/improvement-identifier.md
+          - issue-auditor: reference/jobs/issue-auditor.md
+          - repo-standards: reference/jobs/repo-standards.md
+          - triage-yeti-errors: reference/jobs/triage-yeti-errors.md
+
+extra_css:
+  - stylesheets/extra.css

--- a/site/contributing.md
+++ b/site/contributing.md
@@ -1,0 +1,186 @@
+# Contributing
+
+Yeti is a Frostyard project. Contributions are welcome --- whether that's fixing a bug, adding a job, improving documentation, or just reporting an issue.
+
+---
+
+## Development setup
+
+**Prerequisites:**
+
+- Node.js 22+
+- `gh` CLI (authenticated)
+- `claude` CLI (authenticated) --- needed to run integration-style tests manually
+
+**Getting started:**
+
+```bash
+git clone https://github.com/frostyard/yeti.git
+cd yeti
+npm ci
+npm run build
+npm test
+```
+
+**Development mode:**
+
+```bash
+npm run dev
+```
+
+This runs the project with `tsx` for live TypeScript execution without a build step.
+
+---
+
+## Project structure
+
+```
+src/
+├── main.ts              # Entry point, initialization, shutdown
+├── scheduler.ts         # Job scheduling engine
+├── claude.ts            # AI backend dispatch and worktree management
+├── github.ts            # GitHub API via gh CLI
+├── config.ts            # Configuration loading and live reload
+├── db.ts                # SQLite database
+├── server.ts            # HTTP dashboard
+├── discord.ts           # Discord bot
+├── notify.ts            # Notification dispatcher
+├── error-reporter.ts    # Error deduplication and reporting
+├── jobs/                # One file per job
+│   ├── issue-refiner.ts
+│   ├── plan-reviewer.ts
+│   ├── issue-worker.ts
+│   ├── ci-fixer.ts
+│   ├── auto-merger.ts
+│   ├── review-addresser.ts
+│   ├── doc-maintainer.ts
+│   ├── improvement-identifier.ts
+│   ├── issue-auditor.ts
+│   ├── repo-standards.ts
+│   └── triage-yeti-errors.ts
+├── pages/               # Dashboard HTML builders
+└── test-helpers.ts      # Test factories
+```
+
+---
+
+## Testing
+
+Tests are co-located with source files (`*.test.ts` next to the module they test). Run them with:
+
+```bash
+npm test                                    # all tests
+npx vitest run src/scheduler.test.ts        # single file
+npx vitest run -t "returns ms until"        # by name pattern
+npm run test:watch                          # watch mode
+```
+
+**Testing conventions:**
+
+- External boundaries are mocked: `gh` CLI, `claude` CLI, filesystem operations.
+- Use `vi.mock()` at module level for mocking.
+- Test helpers in `src/test-helpers.ts` provide factories: `mockRepo()`, `mockIssue()`, `mockPR()`.
+- TDD is the expected workflow --- write a failing test, then implement.
+
+---
+
+## Making changes
+
+1. **Create a branch** from `main`:
+
+    ```bash
+    git checkout -b feat/your-feature
+    ```
+
+2. **Write tests first** --- Yeti uses TDD. Start with a failing test that describes the behavior you want.
+
+3. **Implement the change** --- make the test pass.
+
+4. **Check everything builds:**
+
+    ```bash
+    npm run build
+    npm test
+    ```
+
+5. **Consider cross-cutting concerns:**
+    - Changes to `src/config.ts`? Update `deploy/install.sh` and `src/pages/config.ts`.
+    - Changes to job behavior? Update `src/pages/dashboard.ts` and `src/pages/queue.ts`.
+    - New API routes? Update `src/pages/` accordingly.
+    - New or changed config fields? Add form controls in `src/pages/config.ts`.
+
+6. **Update documentation** --- update `CLAUDE.md`, `README.md`, and relevant files in `yeti/` and `site/`.
+
+---
+
+## Adding a new job
+
+Jobs follow a consistent pattern. Each job:
+
+1. Exports a `run()` function
+2. Is registered in `main.ts`
+3. Must be listed in `enabledJobs` to activate
+
+**Steps to add a job:**
+
+1. Create `src/jobs/your-job.ts` with a `run()` export.
+2. Create `src/jobs/your-job.test.ts` with tests.
+3. Register the job in `src/main.ts` with the scheduler.
+4. Add the interval/schedule config to `src/config.ts`.
+5. Add the job name to the type definitions.
+6. Update the dashboard pages if the job introduces new queue categories or states.
+7. Add documentation in `site/reference/jobs/your-job.md` and update `site/reference/jobs/index.md`.
+8. Update `mkdocs.yml` nav to include the new job page.
+
+---
+
+## Commit conventions
+
+Yeti uses conventional commits:
+
+```
+feat: add new capability
+fix: resolve a bug
+refactor: restructure without behavior change
+docs: documentation only
+test: test additions or changes
+chore: build, CI, or tooling changes
+```
+
+Keep commit messages concise. The PR description is where detail belongs.
+
+---
+
+## Release process
+
+Releases are automatic. When changes land on `main`:
+
+1. The release workflow creates a version tag: `v<YYYY-MM-DD>.<N>`
+2. A release tarball is built: `dist/` + `deploy/` + `node_modules/`
+3. The tarball is published as a GitHub release
+4. Deployed instances pick up the release via the auto-updater within 60 seconds
+
+---
+
+## Code style
+
+- **TypeScript** with strict mode enabled
+- **ESM** modules (`"type": "module"` in package.json)
+- No default exports
+- Prefer `const` over `let`, never `var`
+- Error handling at boundaries, not defensively everywhere
+- Keep files focused --- if a file is growing past a few hundred lines, consider splitting
+
+---
+
+## Reporting issues
+
+Found a bug or have a feature idea? Open an issue on the [GitHub repository](https://github.com/frostyard/yeti/issues).
+
+For bug reports, include:
+
+- What you expected to happen
+- What actually happened
+- Relevant log output (`journalctl -u yeti -n 100 --no-pager`)
+- Your Yeti version (`curl localhost:9384/status | jq .version`)
+- Your `enabledJobs` configuration

--- a/site/getting-started/configuration.md
+++ b/site/getting-started/configuration.md
@@ -1,0 +1,129 @@
+# Configuration
+
+Yeti's configuration lives in a single JSON file. Most settings can be changed at runtime without restarting the service, and the web dashboard provides a UI for editing them. This page covers the essentials to get Yeti working after a fresh install.
+
+## Config file
+
+```
+~/.yeti/config.json
+```
+
+The install script creates this file with defaults. It is owned by your user and has `600` permissions (readable only by you, since it may contain tokens).
+
+### Priority order
+
+When the same setting is available in multiple places, the highest-priority source wins:
+
+1. **Environment variables** (set in `~/.yeti/env` or the shell) --- highest priority
+2. **Config file** (`~/.yeti/config.json`)
+3. **Built-in defaults** --- lowest priority
+
+## Essential settings
+
+A fresh install will not process any work until you configure at least `enabledJobs`. Here are the fields to set first:
+
+### `enabledJobs` --- Required
+
+An array of job names to activate. **An empty array means nothing runs.** This is the most important setting to configure.
+
+For a typical starting point, enable the core workflow jobs:
+
+```json
+"enabledJobs": [
+  "issue-refiner",
+  "issue-worker",
+  "ci-fixer",
+  "review-addresser",
+  "auto-merger",
+  "repo-standards"
+]
+```
+
+All available jobs: `issue-refiner`, `issue-worker`, `ci-fixer`, `review-addresser`, `auto-merger`, `doc-maintainer`, `repo-standards`, `improvement-identifier`, `issue-auditor`, `triage-yeti-errors`, `plan-reviewer`.
+
+### `githubOwners`
+
+GitHub organizations or usernames whose repositories Yeti should scan. Defaults to `["frostyard"]`.
+
+```json
+"githubOwners": ["your-org", "your-username"]
+```
+
+### `allowedRepos`
+
+An optional allow-list of specific repositories (by name, not full path) to process. When set, Yeti ignores all other repos under the configured owners. When `null` or omitted, all repos under the owners are eligible.
+
+```json
+"allowedRepos": ["frontend", "api", "docs"]
+```
+
+### `authToken`
+
+A token to protect the web dashboard. When set, all dashboard requests require this token as a query parameter or header. Leave empty to allow unauthenticated access (suitable for private networks).
+
+```json
+"authToken": "your-secret-token"
+```
+
+### `discordBotToken` and `discordChannelId`
+
+Optional. Enable the Discord bot for notifications and commands. Yeti will post job activity to the configured channel and respond to commands like `!yeti issue` and `!yeti look`.
+
+```json
+"discordBotToken": "your-bot-token",
+"discordChannelId": "123456789012345678"
+```
+
+## Minimal config example
+
+A lean configuration to get started. This watches one org, enables the core jobs, and protects the dashboard:
+
+```json
+{
+  "githubOwners": ["your-org"],
+  "enabledJobs": [
+    "issue-refiner",
+    "issue-worker",
+    "ci-fixer",
+    "review-addresser",
+    "auto-merger",
+    "repo-standards"
+  ],
+  "allowedRepos": ["your-first-repo"],
+  "authToken": "pick-something-strong",
+  "discordBotToken": "",
+  "discordChannelId": ""
+}
+```
+
+## Live reload
+
+Most configuration changes take effect without restarting the service. When you edit `~/.yeti/config.json` (or save changes through the dashboard), Yeti picks up the new values on its next config reload cycle.
+
+**Live-reloadable fields:**
+
+- `enabledJobs`, `pausedJobs`
+- `intervals` (all job polling intervals)
+- `schedules` (daily job hours)
+- `skippedItems`, `prioritizedItems`
+- `allowedRepos`, `githubOwners`
+- `authToken`
+- `maxClaudeWorkers`, `claudeTimeoutMs`
+- `maxCopilotWorkers`, `copilotTimeoutMs`
+- `jobAi`
+- `logRetentionDays`, `logRetentionPerJob`
+- `queueScanIntervalMs`
+- `discordAllowedUsers`
+
+**Requires restart:**
+
+- `port` --- the HTTP server binds once at startup
+- `discordBotToken`, `discordChannelId` --- the Discord bot connects once at startup
+
+## Next steps
+
+With Yeti configured and running, it is time to walk through your first issue-to-PR cycle.
+
+[Quickstart guide](quickstart.md){ .md-button .md-button--primary }
+
+For the full reference of every config field, interval default, and environment variable, see the [Configuration Reference](../reference/configuration.md).

--- a/site/getting-started/installation.md
+++ b/site/getting-started/installation.md
@@ -1,0 +1,97 @@
+# Installation
+
+Yeti installs to `/opt/yeti` and runs as a systemd service. The install script handles everything: downloading the latest release, setting up systemd units, and bootstrapping your configuration. The whole process takes a few minutes.
+
+## Prerequisites
+
+Before you begin, make sure the following are available on your Linux host:
+
+| Requirement | Why |
+|---|---|
+| **Node.js 22+** | Yeti's runtime. ESM, strict TypeScript compiled to JS. |
+| **`gh` CLI** | All GitHub interaction goes through the `gh` CLI. Must be authenticated (`gh auth login`). |
+| **`claude` CLI** | Yeti delegates AI work to the Claude CLI. Must be authenticated (`claude auth login`). |
+| **Linux with systemd** | Yeti runs as a managed service with auto-updates via a systemd timer. |
+
+Verify your setup:
+
+```bash
+node --version    # v22.x or later
+gh auth status    # Must show "Logged in"
+claude --version  # Must be installed and authenticated
+```
+
+## Install
+
+A single command downloads the latest release and sets everything up:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/frostyard/yeti/main/deploy/install.sh | bash
+```
+
+Or, if you prefer to inspect the script first:
+
+```bash
+gh release download -R frostyard/yeti --pattern 'yeti.tar.gz' -O /tmp/yeti.tar.gz
+sudo mkdir -p /opt/yeti && sudo chown $(whoami) /opt/yeti
+tar -xzf /tmp/yeti.tar.gz -C /opt/yeti
+/opt/yeti/deploy/install.sh
+```
+
+### What the install script does
+
+1. **Creates `/opt/yeti`** owned by your user (no dedicated service account needed)
+2. **Downloads the latest release tarball** via `gh release download` and extracts it
+3. **Installs three systemd units:**
+    - `yeti.service` --- the main daemon
+    - `yeti-updater.service` --- the update script
+    - `yeti-updater.timer` --- triggers the updater on a schedule
+4. **Bootstraps `~/.yeti/config.json`** with sensible defaults if the file does not already exist
+5. **Creates `~/.yeti/env`** for environment variable overrides
+6. **Enables and starts** both the service and the auto-updater timer
+
+!!! note
+    The install script patches the systemd unit to run as your current user with your current `$PATH`. This ensures `gh`, `claude`, and `node` are all available to the service.
+
+## Post-install
+
+Start Yeti and verify it is running:
+
+```bash
+sudo systemctl start yeti
+curl -s http://localhost:9384/health
+```
+
+A healthy response confirms the daemon is up. Open `http://localhost:9384` in a browser to see the dashboard.
+
+Check the logs if anything looks off:
+
+```bash
+journalctl -u yeti -f
+```
+
+## Auto-updates
+
+Yeti keeps itself current. The `yeti-updater.timer` fires every 60 seconds and runs the deploy script, which:
+
+1. Checks for a new release tag on GitHub
+2. Downloads and extracts the new tarball to a staging directory
+3. Backs up the current `dist/` directory
+4. Stops the service, swaps in the new files, starts the service
+5. Polls the health endpoint for up to 45 seconds
+6. **Rolls back automatically** if the health check fails --- restores the previous `dist/`, restarts, and adds the bad version to a skip list so it will not be retried
+
+Your configuration in `~/.yeti/` is never touched by updates. Only `dist/`, `deploy/`, and `node_modules/` are replaced.
+
+You can check the current version and updater status at any time:
+
+```bash
+cat /opt/yeti/.current-version
+systemctl status yeti-updater.timer
+```
+
+## Next steps
+
+Yeti is running, but it will not do anything useful until you configure which jobs to enable and which repositories to watch.
+
+[Configure Yeti](configuration.md){ .md-button .md-button--primary }

--- a/site/getting-started/quickstart.md
+++ b/site/getting-started/quickstart.md
@@ -1,0 +1,118 @@
+# Quickstart
+
+This guide walks you through Yeti's core workflow: from a fresh issue to a merged pull request. By the end, you will have seen every step of the plan-implement-review-merge loop in action.
+
+## 1. Verify Yeti is running
+
+```bash
+curl -s http://localhost:9384/health
+```
+
+If this returns a response, the daemon is up. If not, check `journalctl -u yeti -f` for errors.
+
+## 2. Open the dashboard
+
+Navigate to `http://localhost:9384` in your browser (append `?token=your-token` if you set an `authToken`).
+
+The dashboard shows:
+
+- **Job status** --- which jobs are active, idle, or paused
+- **Work queue** --- issues and PRs waiting to be processed
+- **Logs** --- recent job runs with full output
+- **Config** --- live editor for `config.json`
+
+Keep the dashboard open in a tab. You will use it to watch Yeti work.
+
+## 3. Confirm labels are synced
+
+The `repo-standards` job runs on startup and on a daily schedule. It ensures all Yeti labels exist on every repository under your configured owners:
+
+| Label | Purpose |
+|---|---|
+| **Needs Refinement** | Tells issue-refiner to generate an implementation plan |
+| **Needs Plan Review** | Triggers adversarial AI review of the plan (when plan-reviewer is enabled) |
+| **Ready** | Signals that a human decision is needed |
+| **Refined** | Tells issue-worker to implement the issue as a PR |
+| **In Review** | Informational --- an open PR exists for this issue |
+| **Priority** | Moves the issue to the front of every processing queue |
+
+If labels are missing on your repo, wait a few minutes for `repo-standards` to run, or trigger it manually from the dashboard.
+
+## 4. Create a test issue
+
+Pick one of the repositories Yeti is watching and create a new issue. Start with something small and well-defined:
+
+> **Title:** Add a timestamp to the footer
+>
+> **Body:** The page footer should display the current year. Add a `<span>` with the year to the existing footer component.
+
+Clear, scoped issues produce the best plans. Yeti reads the full codebase for context, but a precise description helps it focus.
+
+## 5. Label it for refinement
+
+Add the **Needs Refinement** label to your issue.
+
+This is the trigger. Within the next polling interval (5 minutes by default), the `issue-refiner` job will:
+
+1. Clone or update the repo's worktree
+2. Read the codebase and the issue description
+3. Generate a detailed **Implementation Plan** comment on the issue
+4. Remove the `Needs Refinement` label
+
+Watch the dashboard --- you will see the job move from idle to active, and a new entry will appear in the logs.
+
+## 6. Review the plan
+
+Go back to your issue on GitHub. Yeti will have posted a comment with a structured implementation plan: which files to modify, what changes to make, and how to verify them.
+
+Read through it. This is the checkpoint where your judgment matters most.
+
+- **If the plan looks good:** Move on to the next step.
+- **If it needs adjustment:** Post a comment with your feedback and re-add the `Needs Refinement` label. Yeti will generate a revised plan that incorporates your notes.
+- **If plan-reviewer is enabled:** You will also see an adversarial review comment that critiques the plan. The issue will have the `Ready` label, indicating it is waiting for your decision.
+
+## 7. Approve the plan
+
+Add the **Refined** label to the issue.
+
+This tells the `issue-worker` job to implement the plan. On its next polling cycle, it will:
+
+1. Create a fresh worktree on a new branch
+2. Invoke the AI with the plan and full codebase context
+3. Commit the changes and push the branch
+4. Open a pull request linked to the issue
+5. Add the `In Review` label to the issue
+
+## 8. Watch the PR
+
+The pull request appears on GitHub like any other. Yeti's PR description will reference the original issue and summarize the changes.
+
+CI will run. If checks fail, the `ci-fixer` job reads the failure logs and pushes a fix --- no intervention needed on your part. You can watch this happen in real time on the dashboard.
+
+## 9. Review and iterate
+
+Review the PR as you normally would. If you leave comments requesting changes, the `review-addresser` job picks them up and pushes new commits to address them.
+
+The cycle repeats until the PR is in a clean state: tests passing, comments resolved.
+
+## 10. Merge
+
+You have two options:
+
+- **Merge manually** --- Click the merge button on GitHub when you are satisfied.
+- **Let auto-merger handle it** --- If the `auto-merger` job is enabled, it will merge PRs that meet all criteria: CI passing, required approvals present, and no unresolved review threads. Dependency updates and documentation PRs merge on green CI without waiting for manual approval.
+
+Either way, the issue closes when the PR merges. One less item in the backlog.
+
+---
+
+## What to try next
+
+Now that you have seen the full loop, here are some things to explore:
+
+- **Priority issues** --- Add the `Priority` label to an issue and watch it jump to the front of the queue
+- **Skip or pause** --- Use the dashboard config to pause specific jobs or skip individual issues
+- **Multiple repos** --- Remove `allowedRepos` from your config to let Yeti scan all repos under your org
+- **Discord** --- Set up the Discord bot to create issues, trigger analysis, and receive notifications without leaving your chat
+
+For a deeper look at day-to-day usage patterns, see the [Daily Workflow](../usage/daily-workflow.md) guide.

--- a/site/index.md
+++ b/site/index.md
@@ -1,0 +1,79 @@
+# Yeti
+
+**A tireless automation daemon that turns your GitHub issues into pull requests while you sleep.**
+
+Yeti is a self-hosted GitHub automation service that watches your repositories, plans work from issues, implements changes as pull requests, fixes broken CI, and merges when everything is green. It runs quietly on your own infrastructure --- a single Node.js process under systemd --- and keeps a steady pace through your backlog like something well-adapted to cold, remote terrain.
+
+---
+
+## The problem
+
+Software teams generate issues faster than they close them. Every issue follows the same cycle: someone triages it, someone plans the approach, someone writes the code, CI breaks, someone fixes it, someone reviews, someone merges. Each handoff is a context switch. Each context switch is a delay. The backlog grows.
+
+Small teams feel this most. You know *what* needs to happen, but the mechanical work of planning, branching, implementing, and shepherding PRs through review eats your hours. The interesting decisions --- what to build, whether the approach is right, whether the code is good --- get buried under process.
+
+## The solution
+
+Yeti automates the loop between "this issue needs work" and "here's a PR ready for your review."
+
+You label an issue. Yeti reads the codebase, writes an implementation plan, and posts it as a comment. You review the plan --- refine it if needed, approve it when it looks right. Yeti checks out a worktree, generates the implementation, opens a PR, and moves on to the next item. If CI fails, it reads the logs and pushes a fix. If a reviewer leaves comments, it addresses them. When approvals land and checks pass, it merges.
+
+You stay in the driver's seat. Yeti handles the legwork.
+
+## How it works
+
+Yeti runs as a background daemon that polls your GitHub repositories on configurable intervals:
+
+1. **Scan** --- Discovers issues and PRs that need attention across all your repos
+2. **Plan** --- Reads the codebase and generates detailed implementation plans for labeled issues
+3. **Implement** --- Creates branches, writes code in isolated git worktrees, opens pull requests
+4. **Fix** --- Monitors CI results and automatically fixes failures
+5. **Address** --- Responds to review comments on open PRs
+6. **Merge** --- Auto-merges PRs that meet your criteria (passing checks, approvals, clean diff)
+
+Each step runs independently on its own schedule. Work is processed in isolated worktrees, so concurrent tasks never interfere with each other.
+
+## Human-in-the-loop
+
+Yeti is not autonomous. It is deliberate about where it requires your judgment:
+
+- **Plans require approval.** Yeti posts an implementation plan on the issue. You read it, refine it if needed, and add the `Refined` label when it looks right. No label, no PR.
+- **PRs require review.** Yeti opens PRs like any other contributor. Your normal review process applies.
+- **Merging requires criteria.** Auto-merge only triggers when checks pass, approvals exist, and the PR meets your configured standards. Exceptions: dependency updates and documentation PRs, which are low-risk and merge on green CI.
+
+You decide what gets built and whether the approach is correct. Yeti handles the implementation and shepherds it through your pipeline.
+
+## What your workflow looks like
+
+**Without Yeti:** Issue sits in backlog. Someone picks it up days later. Spends time understanding the codebase. Writes code. CI breaks. Fixes CI. Waits for review. Addresses comments. Merges. Repeats.
+
+**With Yeti:**
+
+1. You create an issue describing what you want
+2. Add the `Needs Refinement` label
+3. Within minutes, Yeti posts an implementation plan
+4. You review the plan, add the `Refined` label
+5. Yeti opens a PR with the implementation
+6. You review code at your convenience
+7. Yeti addresses review comments, fixes CI if needed
+8. PR merges when it is ready
+
+The cold reality: most of the time you spent on an issue was not making decisions --- it was executing them. Yeti shifts your time back to the decisions.
+
+## Features
+
+- **11 automated jobs** --- issue refinement, implementation, CI fixing, review addressing, auto-merging, documentation maintenance, repo standards enforcement, improvement identification, issue auditing, plan review, and error triage
+- **Web dashboard** --- Real-time view of job status, work queue, logs, and configuration. Runs on port 9384.
+- **Discord bot** --- Create issues, analyze PRs, trigger jobs, and get notifications from your Discord server
+- **Multi-repo** --- Monitors all repositories under your configured GitHub organizations
+- **Multi-backend AI** --- Route different jobs to Claude or Copilot with per-job model overrides
+- **Priority queue** --- Mark issues as `Priority` to move them to the front of every queue
+- **Live configuration** --- Most settings reload without restart. Pause jobs, skip items, adjust intervals from the dashboard.
+- **Auto-updates** --- A systemd timer checks for new releases every 60 seconds, downloads them, and restarts with health check and automatic rollback
+- **Crash recovery** --- On startup, Yeti detects orphaned tasks from prior crashes, cleans up worktrees, and resumes cleanly
+
+## Get started
+
+Ready to let Yeti settle in? Installation takes about five minutes.
+
+[Install Yeti](getting-started/installation.md){ .md-button .md-button--primary }

--- a/site/reference/api.md
+++ b/site/reference/api.md
@@ -1,0 +1,158 @@
+# HTTP API
+
+Yeti exposes an HTTP server (default port `9384`) that serves both the web dashboard and a set of API endpoints for monitoring and control.
+
+---
+
+## Authentication
+
+When `authToken` is configured, most routes require authentication. Auth is provided via either:
+
+- **Header:** `Authorization: Bearer <token>`
+- **Cookie:** `yeti_token` (set automatically by the login page)
+
+The `/health`, `/status`, `/login`, and `POST /login` routes are accessible without authentication.
+
+---
+
+## Routes
+
+### Public Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Health check. Returns `{"status": "ok", "version": "..."}` |
+| `GET` | `/status` | System status with job states, uptime, queue stats, and integration status (JSON) |
+| `GET` | `/login` | Login page (HTML). Redirects to `/` if auth is disabled |
+| `POST` | `/login` | Submit auth token via form. Sets `yeti_token` cookie on success |
+
+### Dashboard (Auth Required)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/` | Main dashboard -- job status, worker queues, running tasks, schedule info |
+
+### Job Control (Auth Required)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/trigger/:job` | Manually trigger a job. Returns `200` (started), `409` (already running), or `404` (unknown job) |
+| `POST` | `/pause/:job` | Toggle pause/resume for a job. Persists to config file |
+| `POST` | `/cancel` | Cancel the currently-running Claude task (SIGTERM escalation) |
+
+### Queue Management (Auth Required)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/queue` | Work queue page -- items grouped by "My Attention" and "Yeti's Attention" |
+| `POST` | `/queue/merge` | Squash-merge a PR. Body: `{"repo": "owner/name", "prNumber": 123}` |
+| `POST` | `/queue/skip` | Skip an issue/PR. Body: `{"repo": "owner/name", "number": 123}` |
+| `POST` | `/queue/unskip` | Remove a skip. Body: `{"repo": "owner/name", "number": 123}` |
+| `POST` | `/queue/prioritize` | Mark item as high-priority. Body: `{"repo": "owner/name", "number": 123}` |
+| `POST` | `/queue/deprioritize` | Remove priority. Body: `{"repo": "owner/name", "number": 123}` |
+
+### Logs (Auth Required)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/logs` | Log viewer. Supports query params: `?job=<name>` to filter by job, `?search=<term>` to search by item |
+| `GET` | `/logs/:runId` | Individual run detail page with full logs and associated tasks |
+| `GET` | `/logs/:runId/tail` | Live log tail (JSON). Supports `?after=<id>` for polling. Returns `{status, completed_at, logs: [...]}` |
+| `GET` | `/logs/issue` | Issue-specific logs. Requires `?repo=owner/name&number=123` |
+
+### Configuration (Auth Required)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/config` | Config editor page (HTML form). Supports `?saved=1` flash message |
+| `POST` | `/config` | Update config fields via form submission. Triggers live reload. Redirects to `/config?saved=1` |
+| `GET` | `/config/api` | Current config as JSON with sensitive fields masked (auth token, Discord bot token show `****<last 4 chars>`) |
+
+---
+
+## Response Formats
+
+### Health Check
+
+```json
+{
+  "status": "ok",
+  "version": "v2026-03-15.1"
+}
+```
+
+### Status
+
+```json
+{
+  "status": "ok",
+  "startedAt": "2026-03-15T10:00:00.000Z",
+  "uptime": 3600,
+  "jobs": {
+    "issue-refiner": false,
+    "issue-worker": true
+  },
+  "pausedJobs": ["improvement-identifier"],
+  "claudeQueue": { "pending": 0, "active": 1 },
+  "copilotQueue": { "pending": 0, "active": 0 },
+  "runningTasks": [
+    {
+      "jobName": "issue-worker",
+      "repo": "frostyard/yeti",
+      "itemNumber": 42,
+      "startedAt": "2026-03-15T10:30:00"
+    }
+  ],
+  "jobSchedules": {
+    "issue-refiner": {
+      "intervalMs": 300000,
+      "lastCompletedAt": "2026-03-15T10:25:00Z",
+      "nextRunIn": 180000
+    },
+    "doc-maintainer": {
+      "scheduledHour": 1,
+      "lastCompletedAt": "2026-03-15T01:05:00Z",
+      "nextRunIn": 52200000
+    }
+  },
+  "discord": {
+    "connected": true,
+    "guildName": "Frostyard"
+  }
+}
+```
+
+### Trigger Job
+
+```json
+{ "result": "started" }
+```
+
+Possible `result` values: `"started"`, `"already-running"`, `"unknown"`.
+
+### Cancel Task
+
+```json
+{ "result": "cancelled" }
+```
+
+Possible `result` values: `"cancelled"`, `"no-active-task"`.
+
+---
+
+## Queue Categories
+
+The queue page groups items into two sections:
+
+**My Attention** (items waiting for a human):
+
+- `ready` -- Issues with plans ready for review
+
+**Yeti's Attention** (items Yeti is working on or will work on):
+
+- `needs-refinement` -- Issues needing plans
+- `refined` -- Issues approved for implementation
+- `needs-review-addressing` -- PRs with unaddressed review comments
+- `auto-mergeable` -- PRs ready to auto-merge
+- `needs-triage` -- Error issues needing investigation
+- `needs-plan-review` -- Plans awaiting adversarial review

--- a/site/reference/configuration.md
+++ b/site/reference/configuration.md
@@ -1,0 +1,161 @@
+# Configuration Reference
+
+Every setting that shapes how Yeti operates, from the org it watches to the intervals between each patrol of your repositories.
+
+**Config file:** `~/.yeti/config.json`
+
+**Priority:** Environment variables > config file > defaults
+
+Changes to live-reloadable fields take effect without restarting the service. Other fields require a restart.
+
+---
+
+## General Settings
+
+| Field | Type | Default | Env Var | Live Reload | Description |
+|-------|------|---------|---------|:-----------:|-------------|
+| `githubOwners` | `string[]` | `["frostyard"]` | `YETI_GITHUB_OWNERS` (comma-sep) | No | GitHub orgs/users to scan for repositories |
+| `selfRepo` | `string` | `frostyard/yeti` | `YETI_SELF_REPO` | No | Repository where Yeti files error issues about itself |
+| `port` | `number` | `9384` | `PORT` | No | HTTP dashboard port |
+| `authToken` | `string` | `""` | `YETI_AUTH_TOKEN` | No | Dashboard auth token (empty = no auth) |
+| `allowedRepos` | `string[] \| null` | `null` | `YETI_ALLOWED_REPOS` (comma-sep) | No | Repo allow-list. `null` means all repos under `githubOwners` are scanned |
+| `logRetentionDays` | `number` | `14` | -- | Yes | Delete logs older than N days |
+| `logRetentionPerJob` | `number` | `20` | -- | Yes | Max log runs to keep per job |
+| `queueScanIntervalMs` | `number` | `300000` (5 min) | -- | Yes | How often the lightweight queue label scanner runs |
+
+## AI Backend Settings
+
+| Field | Type | Default | Env Var | Live Reload | Description |
+|-------|------|---------|---------|:-----------:|-------------|
+| `maxClaudeWorkers` | `number` | `2` | `YETI_MAX_CLAUDE_WORKERS` | No | Max concurrent Claude CLI processes |
+| `claudeTimeoutMs` | `number` | `1200000` (20 min) | `YETI_CLAUDE_TIMEOUT_MS` | No | Timeout per Claude call (minimum 60s) |
+| `maxCopilotWorkers` | `number` | `1` | `YETI_MAX_COPILOT_WORKERS` | No | Max concurrent Copilot CLI processes |
+| `copilotTimeoutMs` | `number` | `1200000` (20 min) | `YETI_COPILOT_TIMEOUT_MS` | No | Timeout per Copilot call (minimum 60s) |
+| `jobAi` | `Record<string, {backend?, model?}>` | `{}` | -- | Yes | Per-job AI backend and model overrides |
+
+## Discord Integration
+
+| Field | Type | Default | Env Var | Live Reload | Description |
+|-------|------|---------|---------|:-----------:|-------------|
+| `discordBotToken` | `string` | `""` | `YETI_DISCORD_BOT_TOKEN` | No | Discord bot token (requires restart to connect) |
+| `discordChannelId` | `string` | `""` | `YETI_DISCORD_CHANNEL_ID` | No | Discord channel for notifications |
+| `discordAllowedUsers` | `string[]` | `[]` | `YETI_DISCORD_ALLOWED_USERS` (comma-sep) | Yes | Discord user IDs allowed to run commands |
+
+## Job Control
+
+| Field | Type | Default | Env Var | Live Reload | Description |
+|-------|------|---------|---------|:-----------:|-------------|
+| `enabledJobs` | `string[]` | `[]` | -- | Yes | Jobs to register. **Empty = nothing runs.** |
+| `pausedJobs` | `string[]` | `[]` | -- | Yes | Paused job names (registered but not executing) |
+| `skippedItems` | `{repo, number}[]` | `[]` | -- | Yes | Issues/PRs to skip during processing |
+| `prioritizedItems` | `{repo, number}[]` | `[]` | -- | Yes | High-priority items processed first |
+
+## Intervals
+
+All interval fields live inside the `intervals` object, are specified in milliseconds, and are live-reloadable.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `issueWorkerMs` | `300000` (5 min) | issue-worker poll interval |
+| `issueRefinerMs` | `300000` (5 min) | issue-refiner poll interval |
+| `ciFixerMs` | `600000` (10 min) | ci-fixer poll interval |
+| `reviewAddresserMs` | `300000` (5 min) | review-addresser poll interval |
+| `autoMergerMs` | `600000` (10 min) | auto-merger poll interval |
+| `triageYetiErrorsMs` | `600000` (10 min) | triage-yeti-errors poll interval |
+| `planReviewerMs` | `600000` (10 min) | plan-reviewer poll interval |
+
+## Schedules
+
+All schedule fields live inside the `schedules` object, are specified as hour of day in local timezone (0-23), and are live-reloadable.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `docMaintainerHour` | `1` (1 AM) | doc-maintainer run hour |
+| `repoStandardsHour` | `2` (2 AM) | repo-standards run hour |
+| `improvementIdentifierHour` | `3` (3 AM) | improvement-identifier run hour |
+| `issueAuditorHour` | `5` (5 AM) | issue-auditor run hour |
+
+---
+
+## Example: Per-Job AI Overrides
+
+The `jobAi` field lets you route specific jobs to different AI backends or models. This is useful when you want a second perspective -- for instance, running plan reviews through a different provider than the one that wrote the plan.
+
+```json
+{
+  "jobAi": {
+    "plan-reviewer": { "backend": "copilot" },
+    "issue-refiner": { "model": "opus" }
+  }
+}
+```
+
+When a `backend` is specified, the job's work is queued through that backend's worker pool (respecting its own concurrency limits and timeouts). When only a `model` is specified, the job still uses the default Claude backend but passes the model name through.
+
+---
+
+## Example: Minimal Config
+
+A cold-start configuration to get Yeti running on a single org with the essential jobs:
+
+```json
+{
+  "githubOwners": ["my-org"],
+  "selfRepo": "my-org/yeti",
+  "authToken": "a-secret-token",
+  "enabledJobs": [
+    "issue-refiner",
+    "issue-worker",
+    "ci-fixer",
+    "auto-merger",
+    "repo-standards"
+  ]
+}
+```
+
+## Example: Full Config
+
+A more complete configuration with intervals, schedules, and integrations:
+
+```json
+{
+  "githubOwners": ["my-org"],
+  "selfRepo": "my-org/yeti",
+  "authToken": "a-secret-token",
+  "discordBotToken": "discord-bot-token",
+  "discordChannelId": "1234567890",
+  "discordAllowedUsers": ["user-id-1", "user-id-2"],
+  "maxClaudeWorkers": 2,
+  "claudeTimeoutMs": 1200000,
+  "maxCopilotWorkers": 1,
+  "enabledJobs": [
+    "issue-refiner",
+    "plan-reviewer",
+    "issue-worker",
+    "ci-fixer",
+    "auto-merger",
+    "review-addresser",
+    "triage-yeti-errors",
+    "doc-maintainer",
+    "repo-standards",
+    "improvement-identifier",
+    "issue-auditor"
+  ],
+  "intervals": {
+    "issueWorkerMs": 300000,
+    "issueRefinerMs": 300000,
+    "ciFixerMs": 600000
+  },
+  "schedules": {
+    "docMaintainerHour": 1,
+    "repoStandardsHour": 2,
+    "improvementIdentifierHour": 3,
+    "issueAuditorHour": 5
+  },
+  "jobAi": {
+    "plan-reviewer": { "backend": "copilot" }
+  },
+  "logRetentionDays": 14,
+  "logRetentionPerJob": 20
+}
+```

--- a/site/reference/jobs/auto-merger.md
+++ b/site/reference/jobs/auto-merger.md
@@ -1,0 +1,82 @@
+# auto-merger
+
+> Squash-merges qualifying PRs without human intervention -- the final step in the cold chain from issue to shipped code.
+
+| Property | Value |
+|----------|-------|
+| Type | Interval |
+| Default interval | 10 minutes (`intervals.autoMergerMs`) |
+| Uses AI | No |
+| Backend | None (pure GitHub API operations) |
+| Config key | `intervals.autoMergerMs` |
+
+## What it does
+
+The auto-merger watches open PRs and squash-merges those that meet specific criteria. It handles three categories of PRs, each with different merge requirements. No AI is needed -- this is purely a state-checking and merge operation.
+
+## Trigger
+
+Open PRs matching one of three categories:
+
+1. **Dependabot PRs** -- authored by `dependabot[bot]`
+2. **Doc PRs** -- branch name starts with `yeti/docs-`
+3. **Issue PRs** -- branch name starts with `yeti/issue-` or `yeti/improve-`
+
+All other PRs are ignored.
+
+## Labels
+
+| Label | Action |
+|-------|--------|
+| `In Review` | Removes from source issue (after merging a `yeti/issue-*` PR) |
+
+## How it works
+
+### Merge Criteria by Category
+
+**Dependabot PRs:**
+
+- All CI checks must be passing
+
+**Doc PRs (`yeti/docs-*`):**
+
+- All changed files must be under `yeti/` or end in `.md`
+- CI checks must be passing **or** no checks configured
+- Non-doc files in a doc PR cause it to be skipped with a warning
+
+**Issue PRs (`yeti/issue-*`, `yeti/improve-*`):**
+
+- A valid LGTM comment must be posted after the latest commit
+- All CI checks must be passing
+
+### Common Requirements
+
+All categories share these requirements:
+
+- PR must be in `MERGEABLE` state (no conflicts)
+- PR must not be skipped via `skippedItems` config
+
+### Post-Merge Cleanup
+
+After merging a `yeti/issue-*` PR:
+
+1. Extracts the issue number from the branch name (`yeti/issue-<number>-...`)
+2. Removes the `In Review` label from the source issue
+3. Label removal failures are silently ignored (issue may already be closed)
+
+The [issue-worker](issue-worker.md) then detects the merge on its next cycle and handles multi-PR phase continuation if needed.
+
+### LGTM Validation
+
+For issue/improve PRs, the `hasValidLGTM` function checks that:
+
+- An LGTM-style comment exists on the PR
+- The comment was posted **after** the most recent commit
+- This ensures re-review after any changes
+
+## Related jobs
+
+- [issue-worker](issue-worker.md) -- Creates the PRs that auto-merger merges
+- [ci-fixer](ci-fixer.md) -- Fixes CI failures that might block merging
+- [doc-maintainer](doc-maintainer.md) -- Creates doc PRs that auto-merger merges
+- [improvement-identifier](improvement-identifier.md) -- Creates improvement PRs that auto-merger merges

--- a/site/reference/jobs/ci-fixer.md
+++ b/site/reference/jobs/ci-fixer.md
@@ -1,0 +1,114 @@
+# ci-fixer
+
+> Watches for failing CI and merge conflicts on Yeti PRs, then fixes them -- keeping the pipeline clear like a snowplow on a frozen highway.
+
+| Property | Value |
+|----------|-------|
+| Type | Interval |
+| Default interval | 10 minutes (`intervals.ciFixerMs`) |
+| Uses AI | Yes |
+| Backend | Claude (configurable via `jobAi`) |
+| Config key | `intervals.ciFixerMs` |
+
+## What it does
+
+The ci-fixer monitors all open Yeti PRs for problems: merge conflicts, failing CI checks, and cancelled workflows. It uses a two-phase approach -- first identifying all work across all PRs, then processing it -- to prevent race conditions with concurrent GitHub API calls.
+
+When failures are detected, the ci-fixer classifies them as either related to the PR's changes (and fixes them) or unrelated (flakey tests, runner issues), handling each case differently.
+
+## Trigger
+
+Open PRs with any of:
+
+- Merge conflicts (`CONFLICTING` mergeable state)
+- Failing CI checks
+- Cancelled or startup-failure check runs
+
+## Labels
+
+| Label | Action |
+|-------|--------|
+| `Priority` | Respected (priority items are queued first) |
+
+The ci-fixer does not set or remove labels directly. It operates on PRs and lets other jobs manage issue labels.
+
+## How it works
+
+### Phase 1: Identify All Work
+
+The ci-fixer scans every open PR across all repos and classifies each into one of four work types:
+
+| Kind | Condition | Action |
+|------|-----------|--------|
+| `conflict` | PR has `CONFLICTING` mergeable state | Merge base branch, resolve conflicts |
+| `rerun` | Check is `CANCELLED` or `STARTUP_FAILURE` | Re-run the GitHub Actions workflow |
+| `unrelated` | CI failure classified as unrelated to PR changes | File issue, revert previous fixes, merge base |
+| `fix` | CI failure classified as related to PR changes | Use Claude to fix the code |
+
+### Phase 2a: Handle Unrelated Failures
+
+For failures classified as unrelated (grouped by repository):
+
+1. **File a `[ci-unrelated]` issue** -- Creates or updates a tracking issue with the failure fingerprint, affected PR, and abbreviated logs
+2. **Revert previous fix attempts** -- If Yeti previously tried to fix an unrelated failure on this PR, those commits are reverted
+3. **Merge base branch** -- Brings the PR branch up to date, which often resolves pre-existing failures
+
+### Phase 2b: Handle Remaining Items
+
+Processed concurrently:
+
+**Merge Conflicts:**
+
+1. Creates a worktree from the PR branch
+2. Attempts `git merge origin/<base-branch>`
+3. If clean merge: pushes directly
+4. If conflicts: runs Claude to resolve each conflicted file, remove conflict markers, stage, and commit
+5. Updates PR description after resolution
+
+**Re-runs:**
+
+1. Extracts the workflow run ID from the check link
+2. Calls `gh run rerun` to restart the workflow
+
+**CI Fixes (Related Failures):**
+
+1. Creates a worktree from the PR branch
+2. Feeds the failure logs to Claude
+3. Claude analyzes the failure and makes code changes
+4. Pushes changes and updates PR description
+
+### CI Failure Classification
+
+For non-trivial failures, the ci-fixer uses Claude to classify whether the failure is related to the PR's changes. The classifier receives:
+
+- The PR title and branch name
+- Files changed in the PR
+- The CI failure log
+
+It returns a JSON response:
+
+```json
+{
+  "related": true,
+  "fingerprint": "test:auth-timeout",
+  "reason": "Test failure in auth module matches files changed in PR"
+}
+```
+
+Classification rules (safe defaults -- when in doubt, classify as related):
+
+- Failures in files the PR modified: **related**
+- Test failures testing code the PR changed: **related**
+- Flakey tests (timeouts, race conditions): **unrelated**
+- CI runner issues (disk space, network): **unrelated**
+- Pre-existing failures on the base branch: **unrelated**
+
+### Error Handling on ci-unrelated Fix PRs
+
+PRs that fix `[ci-unrelated]` issues (`pr.title.includes("[ci-unrelated]")`) skip the classification step entirely -- their failures are always treated as related. If the fix itself errors out, the error is posted as a comment on the PR rather than creating another error issue.
+
+## Related jobs
+
+- [issue-worker](issue-worker.md) -- Creates the PRs that ci-fixer monitors
+- [auto-merger](auto-merger.md) -- Merges PRs after ci-fixer resolves their issues
+- [review-addresser](review-addresser.md) -- Also operates on open PRs

--- a/site/reference/jobs/doc-maintainer.md
+++ b/site/reference/jobs/doc-maintainer.md
@@ -1,0 +1,68 @@
+# doc-maintainer
+
+> Keeps repository documentation fresh and accurate, updating it while the codebase sleeps.
+
+| Property | Value |
+|----------|-------|
+| Type | Scheduled |
+| Default hour | 1 AM (`schedules.docMaintainerHour`) |
+| Uses AI | Yes |
+| Backend | Claude (configurable via `jobAi`) |
+| Config key | `schedules.docMaintainerHour` |
+
+## What it does
+
+The doc-maintainer runs nightly (and on startup) to ensure the `yeti/` documentation directory stays in sync with the actual codebase. It reads the code, collects implementation plans from recently-closed issues, and uses Claude to create or update documentation optimized for AI consumption.
+
+## Trigger
+
+Scheduled to run once daily. Also runs on startup if the scheduled hour has passed since the last run.
+
+Skips processing when:
+
+- A docs PR (`yeti/docs-*`) is already open for the repo
+- No code has changed since the last documentation update (compared by HEAD SHA)
+- The repo has not been cloned yet (only processes already-cloned repos)
+
+## Labels
+
+This job does not interact with labels.
+
+## How it works
+
+1. **Check for existing docs PR** -- Skips if any open PR has a `yeti/docs-*` branch
+2. **Create worktree** on branch `yeti/docs-<datestamp>-<hex4>`
+3. **Check if maintenance is needed** -- Compares HEAD SHA against the last doc-maintainer commit SHA. Skips if unchanged
+4. **Collect recently-closed issues** -- Fetches issues closed since the last doc update (or 7 days if no previous update). Extracts implementation plans from their comments
+5. **Write temporary plans** -- Up to 10 plans are written to a `.plans/` directory in the worktree (e.g., `.plans/42.md`). Each plan is capped at 5,000 characters
+6. **Run Claude** -- Instructs Claude to:
+    - Read `yeti/OVERVIEW.md` and linked documents
+    - Update documentation to reflect the current code state
+    - Extract architectural context from the collected plans
+    - Keep `OVERVIEW.md` concise (200-500 lines)
+    - Create dedicated docs for complex subsystems
+    - Commit with message `docs: update documentation [doc-maintainer]`
+7. **Clean up** -- Removes the temporary `.plans/` directory (never committed)
+8. **Push and create PR** -- Only if there are actual tree differences. PR titled `docs: update documentation for <repo>`
+
+### Documentation Structure
+
+The doc-maintainer maintains documentation under `yeti/` with this structure:
+
+- **`yeti/OVERVIEW.md`** -- Main entry point: purpose, architecture, key patterns, configuration
+- **Dedicated docs** -- Linked from OVERVIEW.md for complex subsystems (e.g., `yeti/database-schema.md`, `yeti/api-design.md`)
+
+This documentation is written for AI consumption -- maximally useful for understanding the codebase when planning and implementing features, not as user-facing guides.
+
+### Auto-merge Path
+
+Doc PRs created by this job are automatically merged by the [auto-merger](auto-merger.md) when:
+
+- All changed files are under `yeti/` or end in `.md`
+- CI checks pass or no checks are configured
+
+## Related jobs
+
+- [auto-merger](auto-merger.md) -- Merges the doc PRs this job creates
+- [issue-refiner](issue-refiner.md) -- Uses the documentation this job maintains for planning context
+- [issue-worker](issue-worker.md) -- Uses the documentation for implementation context

--- a/site/reference/jobs/improvement-identifier.md
+++ b/site/reference/jobs/improvement-identifier.md
@@ -1,0 +1,76 @@
+# improvement-identifier
+
+> Scans codebases for meaningful improvements and implements them as PRs -- finding warmth in the details others overlook.
+
+| Property | Value |
+|----------|-------|
+| Type | Scheduled |
+| Default hour | 3 AM (`schedules.improvementIdentifierHour`) |
+| Uses AI | Yes |
+| Backend | Claude (configurable via `jobAi`) |
+| Config key | `schedules.improvementIdentifierHour` |
+
+## What it does
+
+The improvement-identifier runs nightly in two phases: first it analyzes the codebase for improvement opportunities, then it implements each one as a separate pull request. It is conservative by design -- only suggesting high-value changes and skipping anything that duplicates existing issues or PRs.
+
+## Trigger
+
+Scheduled to run once daily. Skips a repository if any improvement PR (`yeti/improve-*`) is already open.
+
+## Labels
+
+This job does not interact with labels.
+
+## How it works
+
+### Phase 1: Analysis
+
+1. Creates an isolated git worktree
+2. Fetches all open issue titles and PR titles for deduplication context
+3. Instructs Claude to analyze the codebase, reading `yeti/OVERVIEW.md` for architectural context
+4. Claude returns a JSON list of improvements, each with a title and detailed body
+
+**What Claude looks for:**
+
+- Code that could be consolidated (duplicate or near-duplicate logic)
+- Overcomplicated code that could be simplified
+- Dead code or unused exports/dependencies
+- Performance issues or inefficiencies
+- Security concerns
+- Missing error handling at system boundaries
+- Stale TODOs or FIXMEs that should be addressed
+
+**What Claude is told to ignore:**
+
+- Stylistic changes
+- Comment additions
+- Trivial refactors
+- Type annotations or docstrings
+- Documentation improvements
+
+### Phase 2: Implementation
+
+For each identified improvement (capped at 10 per run):
+
+1. **Deduplication check** -- Searches existing issues and PRs for similar titles. Skips if a match is found
+2. Creates a new worktree on branch `yeti/improve-<hex4>`
+3. Runs Claude with a focused implementation prompt
+4. If changes are produced with actual tree differences, pushes and creates PR titled `refactor: <improvement title>`
+5. PR body includes the improvement description and a footer: `*Automated improvement by yeti improvement-identifier*`
+
+### Conservative Design
+
+The improvement-identifier is intentionally conservative:
+
+- "No improvements found" is a perfectly acceptable result
+- Suggestions must be specific and actionable with exact file references
+- Related improvements are grouped into a single suggestion
+- Existing issues and PRs are checked for duplicates before implementation
+- Maximum 10 improvements per run prevents overwhelming a repository
+- Skips entirely if improvement PRs are already open
+
+## Related jobs
+
+- [auto-merger](auto-merger.md) -- Merges improvement PRs after LGTM
+- [ci-fixer](ci-fixer.md) -- Fixes CI failures on improvement PRs

--- a/site/reference/jobs/index.md
+++ b/site/reference/jobs/index.md
@@ -1,0 +1,86 @@
+# Jobs Overview
+
+Yeti's work is organized into jobs -- each one a focused unit of automation that runs on a timer or a daily schedule. Like a well-organized patrol through frozen terrain, every job has a clear route and knows exactly what to look for.
+
+---
+
+## Interval Jobs
+
+These jobs poll on a timer, checking for new work each cycle.
+
+| Job | Default Interval | AI | Description |
+|-----|:----------------:|:---:|-------------|
+| [issue-refiner](issue-refiner.md) | 5 min | Yes | Generate and refine implementation plans for issues |
+| [plan-reviewer](plan-reviewer.md) | 10 min | Yes | Adversarial review of implementation plans |
+| [issue-worker](issue-worker.md) | 5 min | Yes | Implement approved issues as pull requests |
+| [ci-fixer](ci-fixer.md) | 10 min | Yes | Fix failing CI checks and merge conflicts |
+| [auto-merger](auto-merger.md) | 10 min | No | Auto-merge qualifying pull requests |
+| [review-addresser](review-addresser.md) | 5 min | Yes | Address PR review comments |
+| [triage-yeti-errors](triage-yeti-errors.md) | 10 min | Yes | Investigate Yeti's own error reports |
+
+## Scheduled Jobs
+
+These jobs run once daily at a configured hour (local timezone). They also run on startup if their scheduled time has passed since the last run.
+
+| Job | Default Hour | AI | Description |
+|-----|:-----------:|:---:|-------------|
+| [doc-maintainer](doc-maintainer.md) | 1 AM | Yes | Update repository documentation |
+| [repo-standards](repo-standards.md) | 2 AM | No | Sync labels to all repositories |
+| [improvement-identifier](improvement-identifier.md) | 3 AM | Yes | Find codebase improvements and implement them as PRs |
+| [issue-auditor](issue-auditor.md) | 5 AM | No | Audit and fix issue label state |
+
+---
+
+## Enabling Jobs
+
+**All jobs must be listed in the `enabledJobs` config array to run.** An empty array means nothing runs -- Yeti sits idle, waiting.
+
+```json
+{
+  "enabledJobs": [
+    "issue-refiner",
+    "issue-worker",
+    "ci-fixer"
+  ]
+}
+```
+
+### Recommended Starter Set
+
+If you are setting up Yeti for the first time, start with the core trio:
+
+- **`issue-refiner`** -- Plans issues
+- **`issue-worker`** -- Implements plans as PRs
+- **`ci-fixer`** -- Fixes CI failures on Yeti PRs
+
+Add more jobs as you grow comfortable with the workflow:
+
+- **`auto-merger`** -- Hands-free merging of approved PRs
+- **`repo-standards`** -- Keeps labels in sync
+- **`review-addresser`** -- Handles PR review comments
+
+The full set including nightly jobs (`doc-maintainer`, `improvement-identifier`, `issue-auditor`) rounds out a fully autonomous setup.
+
+---
+
+## Job Behavior
+
+### Skip-if-Busy
+
+Jobs use skip-if-busy scheduling: if a job's previous run is still active when the next interval fires, the new run is silently skipped. This prevents queue pile-up during long-running tasks.
+
+### Pause and Resume
+
+Jobs can be paused via the dashboard or API (`POST /pause/:job`). Paused jobs remain registered but do not execute. The pause state is persisted to `config.json`.
+
+### Manual Trigger
+
+Any job can be manually triggered via the dashboard or API (`POST /trigger/:job`), regardless of its normal schedule. Manual triggers respect skip-if-busy -- if the job is already running, the trigger returns `409`.
+
+### AI Backend
+
+Jobs marked "AI: Yes" use Claude CLI by default. Individual jobs can be routed to a different backend (e.g., Copilot) or model via the [`jobAi` config](../configuration.md#example-per-job-ai-overrides).
+
+### Rate Limiting
+
+All jobs respect the GitHub API rate limit circuit breaker. When rate limiting is detected, jobs stop processing new items and wait for the 60-second cooldown to expire.

--- a/site/reference/jobs/issue-auditor.md
+++ b/site/reference/jobs/issue-auditor.md
@@ -1,0 +1,83 @@
+# issue-auditor
+
+> Audits issue labels for drift and inconsistency -- a nightly patrol to keep the trail markers accurate.
+
+| Property | Value |
+|----------|-------|
+| Type | Scheduled |
+| Default hour | 5 AM (`schedules.issueAuditorHour`) |
+| Uses AI | No |
+| Backend | None (pure GitHub API operations) |
+| Config key | `schedules.issueAuditorHour` |
+
+## What it does
+
+The issue-auditor scans all open issues across all repos and verifies that their labels accurately reflect their actual state. It fixes label drift -- situations where an issue's labels have become inconsistent with reality (e.g., a PR was closed but `In Review` was never removed).
+
+After the audit, it sends a Discord notification summarizing all fixes made.
+
+## Trigger
+
+Scheduled to run once daily. No prerequisites other than being enabled.
+
+## Labels
+
+| Label | Action |
+|-------|--------|
+| `In Review` | Sets (if issue has an open Yeti PR but label is missing) |
+| `In Review` | Removes (if issue has no open Yeti PR but label is present) |
+| `Ready` | Sets (if issue has a plan with all feedback addressed but label is missing) |
+| `Ready` | Sets (if multi-phase issue is stuck -- merged PRs exist but more phases remain without `Refined`) |
+
+## How it works
+
+### Issue Classification
+
+The auditor classifies each open issue into one of six states:
+
+| State | Condition |
+|-------|-----------|
+| `refined` | Has the `Refined` label (being processed by issue-worker) |
+| `in-progress` | Has an open Yeti PR (`yeti/issue-*` or `yeti/improve-*`) |
+| `needs-triage` | Is a `[yeti-error]` issue without an investigation report |
+| `needs-refinement` | No plan exists, or plan exists with unreacted human feedback |
+| `ready` | Plan exists with all feedback addressed |
+| `stuck-multi-phase` | Has merged PRs but more phases remain without `Refined` label |
+
+### Fix Rules
+
+Based on the classification, the auditor applies these corrections:
+
+**`In Review` label:**
+
+- If state is `in-progress` and label is missing: **add** `In Review`
+- If state is not `in-progress` and label is present: **remove** `In Review`
+
+**`Ready` label:**
+
+- If state is `ready` and label is missing: **add** `Ready`
+- If state is `stuck-multi-phase` and `Ready` is missing: **add** `Ready` (flags for human attention)
+
+### Notification
+
+After processing all repos, the auditor sends a Discord notification with a summary of all fixes applied. Example:
+
+> Issue auditor: fixed 3 issue(s) -- added In Review to myorg/repo#42, removed stale In Review from myorg/repo#37, added Ready to stuck multi-phase myorg/repo#25
+
+If no fixes were needed, no notification is sent.
+
+### Unreacted Comment Detection
+
+To determine if an issue needs refinement, the auditor checks for unreacted human comments after the last plan. It uses the same logic as the [issue-refiner](issue-refiner.md):
+
+1. Find the last `## Implementation Plan` comment posted by Yeti
+2. Look at all comments after it
+3. Skip bot comments and Yeti's own comments
+4. Check each comment for a thumbsup reaction from Yeti
+5. If any comment lacks a reaction, the issue needs refinement
+
+## Related jobs
+
+- [issue-refiner](issue-refiner.md) -- Handles issues that the auditor identifies as needing refinement
+- [issue-worker](issue-worker.md) -- Handles issues the auditor identifies as stuck multi-phase
+- [triage-yeti-errors](triage-yeti-errors.md) -- Handles `[yeti-error]` issues the auditor identifies as needing triage

--- a/site/reference/jobs/issue-refiner.md
+++ b/site/reference/jobs/issue-refiner.md
@@ -1,0 +1,81 @@
+# issue-refiner
+
+> Generates and refines implementation plans for issues, turning cold requirements into warm, actionable blueprints.
+
+| Property | Value |
+|----------|-------|
+| Type | Interval |
+| Default interval | 5 minutes (`intervals.issueRefinerMs`) |
+| Uses AI | Yes |
+| Backend | Claude (configurable via `jobAi`) |
+| Config key | `intervals.issueRefinerMs` |
+
+## What it does
+
+The issue-refiner is the planning engine at the heart of Yeti's workflow. It reads GitHub issues and produces detailed implementation plans -- which files to change, what the changes should be, risks, edge cases, and a suggested implementation order.
+
+When feedback arrives on an existing plan, the refiner updates the plan in-place rather than posting a new comment, keeping the issue thread clean. It also handles follow-up questions on issues that already have open PRs.
+
+## Trigger
+
+The refiner processes an issue when any of these conditions are met:
+
+1. **New plan needed:** Issue has the `Needs Refinement` label and no existing plan comment
+2. **Re-plan requested:** Issue has the `Needs Refinement` label and an existing plan (produces a fresh plan)
+3. **Feedback to address:** Issue has an existing plan with unreacted human comments posted after it
+4. **Auto-plan exemptions:** `[ci-unrelated]` or `[yeti-error]` issues (with triage report) are processed without requiring the `Needs Refinement` label
+5. **Follow-up questions:** Issues with open PRs and unreacted human comments after the plan
+
+## Labels
+
+| Label | Action |
+|-------|--------|
+| `Needs Refinement` | Requires (for new plans on regular issues) |
+| `Needs Refinement` | Removes (after posting plan) |
+| `Needs Plan Review` | Sets (if plan-reviewer is enabled) |
+| `Ready` | Sets (if plan-reviewer is disabled) |
+| `Ready` | Removes (when new feedback arrives) |
+| `Refined` | Sets (auto-refines `[ci-unrelated]` issues) |
+
+## How it works
+
+### New Plan
+
+1. Creates an isolated git worktree for the repository
+2. Reads the issue body, all comments, and any referenced images
+3. Instructs Claude to read `yeti/OVERVIEW.md` and linked docs for codebase context
+4. Claude produces the plan (text only, no code changes)
+5. Posts an `## Implementation Plan` comment on the issue
+6. Transitions labels: removes `Needs Refinement`, adds `Needs Plan Review` or `Ready`
+7. For `[ci-unrelated]` issues: also adds `Refined` to skip human approval
+
+### Refinement (Feedback Loop)
+
+1. Detects unreacted human comments after the most recent plan
+2. Feeds the existing plan and new feedback to Claude
+3. Claude produces an updated plan
+4. **Edits the existing plan comment** in-place (does not create a new comment)
+5. If Claude includes a `### Note` section, it is posted as a separate comment
+6. Reacts with thumbsup to each addressed feedback comment
+7. Re-adds `Needs Plan Review` or `Ready`
+
+### Follow-Up Response
+
+When an issue has an open PR but new human comments appear:
+
+1. Detects unreacted comments on issues with open Yeti PRs
+2. Feeds the existing plan, PR number, and follow-up comments to Claude
+3. Claude responds to questions and clarifications (no new plan produced)
+4. Posts the response as a comment
+5. Reacts with thumbsup to each addressed comment
+
+### Multi-PR Plans
+
+The refiner instructs Claude to prefer single PRs but supports multi-PR plans for genuinely large changes. Multi-PR plans use a structured format (`### PR 1: ...`, `### PR 2: ...`) that the [issue-worker](issue-worker.md) parses for phased implementation.
+
+## Related jobs
+
+- [plan-reviewer](plan-reviewer.md) -- Reviews plans produced by the refiner
+- [issue-worker](issue-worker.md) -- Implements approved plans
+- [issue-auditor](issue-auditor.md) -- Detects issues needing refinement
+- [triage-yeti-errors](triage-yeti-errors.md) -- Must triage `[yeti-error]` issues before the refiner processes them

--- a/site/reference/jobs/issue-worker.md
+++ b/site/reference/jobs/issue-worker.md
@@ -1,0 +1,81 @@
+# issue-worker
+
+> Implements approved issues as pull requests -- the job that turns plans into code.
+
+| Property | Value |
+|----------|-------|
+| Type | Interval |
+| Default interval | 5 minutes (`intervals.issueWorkerMs`) |
+| Uses AI | Yes |
+| Backend | Claude (configurable via `jobAi`) |
+| Config key | `intervals.issueWorkerMs` |
+
+## What it does
+
+The issue-worker is the implementation engine. When an issue is approved with the `Refined` label, this job creates an isolated git worktree, runs Claude with the implementation plan, and opens a pull request with the resulting changes.
+
+It handles both single-PR and multi-PR implementations, tracking phase progress across the lifecycle of complex issues.
+
+## Trigger
+
+- Issues with the `Refined` label (new implementation)
+- Open issues with merged Yeti PRs but remaining phases (multi-PR continuation)
+
+## Labels
+
+| Label | Action |
+|-------|--------|
+| `Refined` | Requires (to start implementation) |
+| `Refined` | Removes (after creating PR or if PR already exists) |
+| `Ready` | Removes (when starting implementation) |
+| `In Review` | Sets (after creating PR) |
+| `Priority` | Propagates from issue to new PR |
+| `Refined` | Sets (re-labels issue for next multi-PR phase after merge) |
+
+## How it works
+
+### Single-PR Implementation
+
+1. Checks for an existing open PR for the issue (skips if found, removes `Refined`)
+2. Removes the `Ready` label
+3. Creates a git worktree on branch `yeti/issue-<number>-<hex4>`
+4. Reads the `## Implementation Plan` comment from the issue
+5. Runs Claude with the plan, issue body, and all comments
+6. **Tree-diff guard:** Only pushes if there are both new commits AND actual tree differences vs. the default branch
+7. Generates a PR description summarizing the changes
+8. Creates PR titled `fix: resolve #<N> -- <issue title>` with body ending in `Closes #<N>`
+9. Adds `In Review` label to the issue
+10. Propagates `Priority` label to the PR if the issue has it
+11. Removes `Refined` label
+
+### Multi-PR Implementation
+
+When the plan specifies multiple phases (using `### PR 1: ...`, `### PR 2: ...` format):
+
+1. Determines the current phase based on how many PRs have already been merged
+2. Posts a progress comment on the issue: `## Phase Progress`
+3. Builds a phase-aware prompt -- Claude sees the full plan but is told to implement only the current phase
+4. Creates PR titled `fix(#<N>): <phase title> (<M>/<total>)`
+5. Intermediate PRs: body says `Part of #<N>`
+6. Final PR: body says `Closes #<N>`
+
+### Phase Continuation
+
+After a multi-PR phase is merged:
+
+1. The worker detects open issues with merged Yeti PRs but remaining phases
+2. Confirms no open PR currently exists
+3. Re-adds the `Refined` label to trigger the next phase
+4. On the next poll cycle, the standard flow picks up the issue again
+
+### Guards
+
+- **Duplicate PR guard:** Uses `getOpenPRForIssue` with cache bypass (`fresh: true`) to prevent race conditions where a concurrent PR is invisible during the 60-second cache window
+- **Tree-diff guard:** Checks both `hasNewCommits` (commit count) and `hasTreeDiff` (actual tree difference via `git diff --quiet`) before pushing. This prevents failures when commits produce no effective changes.
+
+## Related jobs
+
+- [issue-refiner](issue-refiner.md) -- Produces the plans this job implements
+- [ci-fixer](ci-fixer.md) -- Fixes CI failures on the PRs this job creates
+- [review-addresser](review-addresser.md) -- Addresses review comments on the PRs this job creates
+- [auto-merger](auto-merger.md) -- Merges the PRs this job creates

--- a/site/reference/jobs/plan-reviewer.md
+++ b/site/reference/jobs/plan-reviewer.md
@@ -1,0 +1,73 @@
+# plan-reviewer
+
+> Adversarial review of implementation plans -- a second pair of eyes before a human decides.
+
+| Property | Value |
+|----------|-------|
+| Type | Interval |
+| Default interval | 10 minutes (`intervals.planReviewerMs`) |
+| Uses AI | Yes |
+| Backend | Configurable (defaults to Claude, commonly set to Copilot for a different perspective) |
+| Config key | `intervals.planReviewerMs` |
+
+## What it does
+
+The plan-reviewer provides an adversarial critique of implementation plans. It reads the plan and the original issue, then posts a review highlighting gaps, risks, edge cases, missing test coverage, and over-engineering concerns.
+
+The review is written **for the human**, not for automatic AI refinement. When plan-reviewer is enabled, the workflow becomes human-in-the-loop: issue-refiner produces a plan, plan-reviewer critiques it, both land on the issue as comments with the `Ready` label, and a human reads both before deciding to approve or request changes.
+
+## Trigger
+
+Issues with the `Needs Plan Review` label that have an unreviewed plan comment (no thumbsup reaction from Yeti on the plan comment).
+
+## Labels
+
+| Label | Action |
+|-------|--------|
+| `Needs Plan Review` | Requires |
+| `Needs Plan Review` | Removes (after posting review) |
+| `Ready` | Sets (after posting review) |
+
+## How it works
+
+1. Scans open issues for the `Needs Plan Review` label
+2. Finds the most recent `## Implementation Plan` comment (posted by Yeti)
+3. Checks if the plan has already been reviewed (thumbsup reaction from Yeti)
+4. Creates an isolated git worktree for the repository
+5. Builds a prompt with the issue details and the plan
+6. Runs the AI (Claude or Copilot, based on `jobAi` config) to critique the plan
+7. Posts a `## Plan Review` comment on the issue
+8. Reacts with thumbsup to the plan comment (marks it as reviewed)
+9. Removes `Needs Plan Review`, adds `Ready`
+
+### Review Focus Areas
+
+The reviewer is instructed to look for:
+
+- Missing edge cases or error handling
+- Files that should be modified but are not mentioned
+- Incorrect assumptions about the codebase
+- Risks that are not acknowledged
+- Over-engineering or unnecessary complexity
+- Missing test coverage
+
+If the plan is solid, the review says so briefly.
+
+### Backend Configuration
+
+A common pattern is to route the plan-reviewer through a different AI backend than the refiner that wrote the plan. This provides genuine diversity of perspective:
+
+```json
+{
+  "jobAi": {
+    "plan-reviewer": { "backend": "copilot" }
+  }
+}
+```
+
+When the backend is set to `copilot`, the job's work is queued through the Copilot worker pool with its own concurrency limits.
+
+## Related jobs
+
+- [issue-refiner](issue-refiner.md) -- Produces the plans that this job reviews
+- [issue-worker](issue-worker.md) -- Implements plans after human approval

--- a/site/reference/jobs/repo-standards.md
+++ b/site/reference/jobs/repo-standards.md
@@ -1,0 +1,56 @@
+# repo-standards
+
+> Syncs Yeti's label definitions to all scanned repositories and cleans up the remnants of older seasons.
+
+| Property | Value |
+|----------|-------|
+| Type | Scheduled |
+| Default hour | 2 AM (`schedules.repoStandardsHour`) |
+| Uses AI | No |
+| Backend | None (pure GitHub API operations) |
+| Config key | `schedules.repoStandardsHour` |
+
+## What it does
+
+The repo-standards job ensures that all six Yeti labels exist on every repository Yeti scans, with the correct names, colors, and descriptions. It also cleans up legacy labels from previous versions of Yeti.
+
+This is the simplest job in Yeti's arsenal -- no AI, no worktrees, no complex logic. It just makes sure the signaling infrastructure is in place.
+
+## Trigger
+
+Scheduled to run once daily. Also runs on startup.
+
+## Labels
+
+| Label | Color | Description | Action |
+|-------|-------|-------------|--------|
+| `Needs Refinement` | `#d876e3` | Issue needs an AI-generated implementation plan | Creates if missing |
+| `Needs Plan Review` | `#c5def5` | Plan awaiting adversarial AI review | Creates if missing |
+| `Ready` | `#0e8a16` | Yeti has finished -- needs human attention | Creates if missing |
+| `Refined` | `#0075ca` | Issue is ready for yeti to implement | Creates if missing |
+| `In Review` | `#fbca04` | Issue has an open PR being reviewed | Creates if missing |
+| `Priority` | `#d93f0b` | High-priority -- processed first in all Yeti queues | Creates if missing |
+
+## How it works
+
+For each repository in the scan list:
+
+1. **Ensure all labels** -- Creates any missing Yeti labels with the correct color and description. If a label already exists, it is left as-is (colors and descriptions are not forcibly updated)
+2. **Delete legacy labels** -- Removes labels from previous versions of Yeti that are no longer used
+
+### Legacy Labels Deleted
+
+The following labels are automatically cleaned up:
+
+- `Plan Produced`
+- `Reviewed`
+- `prod-report`
+- `investigated`
+- `yeti-mergeable`
+- `yeti-error`
+
+Deletion failures are silently ignored (the label may have already been removed or may never have existed on a given repository).
+
+## Related jobs
+
+All other jobs depend on repo-standards having run at least once to ensure the necessary labels exist on each repository. In practice, this is handled automatically since repo-standards runs on startup.

--- a/site/reference/jobs/review-addresser.md
+++ b/site/reference/jobs/review-addresser.md
@@ -1,0 +1,59 @@
+# review-addresser
+
+> Addresses PR review comments on Yeti-created pull requests, responding to feedback without waiting for the next thaw.
+
+| Property | Value |
+|----------|-------|
+| Type | Interval |
+| Default interval | 5 minutes (`intervals.reviewAddresserMs`) |
+| Uses AI | Yes |
+| Backend | Claude (configurable via `jobAi`) |
+| Config key | `intervals.reviewAddresserMs` |
+
+## What it does
+
+When reviewers leave comments on Yeti-created PRs, the review-addresser picks them up and uses Claude to either make code changes or post text explanations. It handles both inline review comments and general PR comments, pushing changes and posting a summary when done.
+
+## Trigger
+
+Yeti-created PRs (branch starts with `yeti/`) with unaddressed review comments. A comment is considered "unaddressed" if it has no thumbsup reaction from Yeti.
+
+Both regular issue comments and pull request review comments (inline code comments) are collected and processed together.
+
+## Labels
+
+| Label | Action |
+|-------|--------|
+| `Ready` | Removes (before processing, to signal work is in progress) |
+| `Ready` | Sets (after addressing comments, to signal the PR needs another look) |
+
+## How it works
+
+1. Scans all open PRs across all repos for `yeti/` branches
+2. Fetches review comments and issue comments on each PR
+3. Filters to only unaddressed comments (no thumbsup reaction from Yeti)
+4. If unaddressed comments exist:
+   a. Removes the `Ready` label from the PR
+   b. Creates a worktree from the PR branch
+   c. Collects the formatted review data and any referenced images
+   d. Feeds all review comments to Claude with instructions to make code changes or explain why no changes are needed
+   e. If Claude produces commits with actual tree differences, pushes the changes
+   f. Updates the PR description to reflect the changes
+   g. Posts Claude's summary as a comment on the PR
+   h. Reacts with thumbsup to each addressed comment (both regular and inline review comments)
+   i. Adds the `Ready` label to signal the PR needs another review
+
+### Comment Processing
+
+The review-addresser processes both types of GitHub comments:
+
+- **Issue comments** -- General comments on the PR conversation thread
+- **Review comments** -- Inline comments attached to specific lines of code
+
+Both are collected into a single formatted prompt for Claude. The thumbsup reactions are tracked separately for each comment type using different GitHub API endpoints.
+
+## Related jobs
+
+- [issue-worker](issue-worker.md) -- Creates the PRs that this job monitors
+- [ci-fixer](ci-fixer.md) -- Also operates on open Yeti PRs
+- [auto-merger](auto-merger.md) -- Merges PRs after review comments are addressed

--- a/site/reference/jobs/triage-yeti-errors.md
+++ b/site/reference/jobs/triage-yeti-errors.md
@@ -1,0 +1,84 @@
+# triage-yeti-errors
+
+> Investigates Yeti's own error reports -- when the yeti stumbles, it picks itself back up and figures out what happened.
+
+| Property | Value |
+|----------|-------|
+| Type | Interval |
+| Default interval | 10 minutes (`intervals.triageYetiErrorsMs`) |
+| Uses AI | Yes |
+| Backend | Claude (configurable via `jobAi`) |
+| Config key | `intervals.triageYetiErrorsMs` |
+
+## What it does
+
+When Yeti encounters errors during operation, the [error-reporter](../configuration.md) creates `[yeti-error]` issues on the `selfRepo`. This job investigates those errors: it deduplicates them, runs Claude to analyze stack traces and source code, determines the root cause, and posts an investigation report.
+
+Only operates on the configured `selfRepo` (default: `frostyard/yeti`).
+
+## Trigger
+
+Open issues on `selfRepo` with titles matching `[yeti-error] <fingerprint>` that do not yet have a `## Yeti Error Investigation Report` comment.
+
+## Labels
+
+This job does not interact with labels directly. However, after a triage report is posted, the [issue-refiner](issue-refiner.md) may then process the issue for planning if it has the `Needs Refinement` label.
+
+## How it works
+
+### Phase 1: Deduplication by Fingerprint
+
+Before investigating, the job deduplicates error issues by their fingerprint (extracted from the title):
+
+1. Groups uninvestigated issues by fingerprint
+2. For each fingerprint group:
+   - If an existing (already-investigated) issue has the same fingerprint: closes the new issues as duplicates with a comment referencing the canonical issue
+   - If multiple new issues share a fingerprint: keeps the oldest, closes the rest as duplicates
+3. Also checks "known fingerprints" lists on existing issues (maintained by Phase 2)
+
+### Phase 2: Investigation
+
+For each canonical (non-duplicate) issue:
+
+1. Creates an isolated git worktree of `selfRepo`
+2. Parses the error details from the issue body:
+   - **Fingerprint:** The error class identifier (e.g., `ci-fixer:merge-conflict`)
+   - **Context:** Where the error occurred (e.g., `frostyard/repo#42`)
+   - **Timestamp:** When the error occurred
+   - **Error text:** The stack trace or error message
+3. Maps the fingerprint to likely source files (e.g., `ci-fixer` maps to `src/jobs/ci-fixer.ts`)
+4. Builds an investigation prompt that includes:
+   - The error details
+   - Summaries of other open error issues (for cross-referencing)
+   - Instructions to read `yeti/OVERVIEW.md` and linked docs
+   - Instructions to read source code and run verification commands
+5. Claude investigates: reads the codebase, analyzes the error path, determines root cause
+6. Claude's output ends with `RELATED_ISSUES: <numbers or "none">`
+7. Posts `## Yeti Error Investigation Report` comment (without the RELATED_ISSUES line)
+
+### Phase 2 Deduplication: By Root Cause
+
+After investigation, if Claude identified related issues:
+
+1. Closes related issues as duplicates with a comment explaining the shared root cause
+2. Collects fingerprints from all closed related issues
+3. Updates a `### Known Fingerprints` comment on the canonical issue listing all associated fingerprints
+4. This fingerprint list is used by Phase 1 in future runs to catch duplicates even when titles differ
+
+### Fingerprint Format
+
+Error fingerprints follow the pattern `<job-name>:<error-type>`. The job name portion is used to suggest which source file to read during investigation. Examples:
+
+- `ci-fixer:merge-conflict`
+- `issue-worker:process-issue`
+- `github:rate-limit`
+
+### Relationship with Other Jobs
+
+After the triage report is posted, the issue becomes eligible for the [issue-refiner](issue-refiner.md). The refiner will not process `[yeti-error]` issues until they have a triage report, ensuring the error is understood before a fix is planned.
+
+## Related jobs
+
+- [issue-refiner](issue-refiner.md) -- Plans fixes after triage is complete (requires `Needs Refinement` label)
+- [issue-worker](issue-worker.md) -- Implements the planned fix
+- [issue-auditor](issue-auditor.md) -- Classifies uninvestigated `[yeti-error]` issues as `needs-triage`

--- a/site/reference/labels.md
+++ b/site/reference/labels.md
@@ -1,0 +1,121 @@
+# Labels
+
+Yeti manages six labels across all repositories it watches. These labels form the signaling layer of the issue lifecycle -- each one marks a distinct station in the journey from idea to merged code.
+
+Labels are synced to repos by the [repo-standards](jobs/repo-standards.md) job, so you never need to create them manually.
+
+---
+
+## Label Summary
+
+| Label | Color | Meaning |
+|-------|-------|---------|
+| **Needs Refinement** | Purple | This issue needs an AI-generated implementation plan |
+| **Needs Plan Review** | Light blue | Plan awaiting adversarial AI review |
+| **Ready** | Green | Yeti has finished -- needs human attention |
+| **Refined** | Blue | Plan approved -- Yeti should implement this |
+| **In Review** | Yellow | There is an open PR for this issue |
+| **Priority** | Red | Process this item before others in all queues |
+
+---
+
+## Needs Refinement
+
+> *"This issue needs an AI-generated implementation plan."*
+
+The starting signal. When this label appears on an issue, the [issue-refiner](jobs/issue-refiner.md) picks it up and generates a detailed implementation plan.
+
+| | Details |
+|---|---------|
+| **Set by** | Human (manually), [issue-auditor](jobs/issue-auditor.md) (if issue has no plan) |
+| **Removed by** | [issue-refiner](jobs/issue-refiner.md) (after posting or updating the plan) |
+| **Color** | `#d876e3` (purple) |
+
+**Note:** Machine-generated issues (`[ci-unrelated]` and `[yeti-error]`) are exempt from requiring this label -- the issue-refiner processes them automatically based on their title prefix.
+
+---
+
+## Needs Plan Review
+
+> *"Plan awaiting adversarial AI review before a human sees it."*
+
+An intermediate step that only activates when the [plan-reviewer](jobs/plan-reviewer.md) job is enabled. The plan-reviewer critiques the implementation plan, looking for gaps, risks, and edge cases. The review is written for the human, not for automatic AI refinement.
+
+| | Details |
+|---|---------|
+| **Set by** | [issue-refiner](jobs/issue-refiner.md) (after posting plan, if plan-reviewer is enabled) |
+| **Removed by** | [plan-reviewer](jobs/plan-reviewer.md) (after posting review) |
+| **Color** | `#c5def5` (light blue) |
+
+If the plan-reviewer job is not in `enabledJobs`, this label is never used. The issue-refiner skips straight to adding `Ready` instead.
+
+---
+
+## Ready
+
+> *"Yeti has finished its work -- a human needs to decide next steps."*
+
+This label is Yeti's way of handing control back to a human. An issue with `Ready` has a plan (and possibly a review) waiting for someone to read and either approve it by adding `Refined`, or post feedback comments to trigger another refinement cycle.
+
+| | Details |
+|---|---------|
+| **Set by** | [issue-refiner](jobs/issue-refiner.md) (after plan, if plan-reviewer disabled), [plan-reviewer](jobs/plan-reviewer.md) (after review), [review-addresser](jobs/review-addresser.md) (after addressing PR comments), [issue-auditor](jobs/issue-auditor.md) (for stuck items) |
+| **Removed by** | [issue-worker](jobs/issue-worker.md) (when starting implementation), [issue-refiner](jobs/issue-refiner.md) (when new feedback arrives) |
+| **Color** | `#0e8a16` (green) |
+
+---
+
+## Refined
+
+> *"Plan approved -- Yeti should implement this."*
+
+The green light. Adding this label tells the [issue-worker](jobs/issue-worker.md) to create a worktree, run Claude against the plan, and open a PR with the implementation.
+
+| | Details |
+|---|---------|
+| **Set by** | Human (approval of plan), Discord `!yeti assign` command, [issue-worker](jobs/issue-worker.md) (re-labels for next phase in multi-PR workflows), [issue-refiner](jobs/issue-refiner.md) (auto-refines `[ci-unrelated]` issues) |
+| **Removed by** | [issue-worker](jobs/issue-worker.md) (after creating PR or if a PR already exists) |
+| **Color** | `#0075ca` (blue) |
+
+---
+
+## In Review
+
+> *"There is an open PR for this issue."*
+
+An informational label that tracks which issues currently have active pull requests. Helps keep the dashboard queue accurate and prevents duplicate work.
+
+| | Details |
+|---|---------|
+| **Set by** | [issue-worker](jobs/issue-worker.md) (after creating PR), [issue-auditor](jobs/issue-auditor.md) (if PR is open but label is missing) |
+| **Removed by** | [auto-merger](jobs/auto-merger.md) (after merge), [issue-auditor](jobs/issue-auditor.md) (if PR is no longer open) |
+| **Color** | `#fbca04` (yellow) |
+
+---
+
+## Priority
+
+> *"Process this item before others in all queues."*
+
+A queue-ordering signal. Priority items are dequeued ahead of non-priority items in all AI worker queues. Can be set on both issues and PRs.
+
+| | Details |
+|---|---------|
+| **Set by** | Human (via dashboard or manually) |
+| **Removed by** | Human |
+| **Color** | `#d93f0b` (red) |
+
+When an issue has the Priority label and the issue-worker creates a PR for it, the Priority label is propagated to the new PR as well.
+
+---
+
+## Legacy Labels
+
+The following labels were used by earlier versions of Yeti and are now obsolete. The [repo-standards](jobs/repo-standards.md) job automatically deletes them from all scanned repositories:
+
+- `Plan Produced`
+- `Reviewed`
+- `prod-report`
+- `investigated`
+- `yeti-mergeable`
+- `yeti-error`

--- a/site/reference/workflow.md
+++ b/site/reference/workflow.md
@@ -1,0 +1,275 @@
+# Issue Lifecycle
+
+The complete journey of an issue through Yeti, from the first flake of an idea to a merged pull request. This is the most important reference page -- understanding this flow is understanding how Yeti works.
+
+---
+
+## State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Created: New issue
+    Created --> Planning: Add "Needs Refinement" label
+    Planning --> PlanReview: plan-reviewer enabled
+    Planning --> HumanReview: plan-reviewer disabled
+    PlanReview --> HumanReview: Review posted, "Ready" added
+    HumanReview --> Feedback: Human posts comments
+    Feedback --> Planning: issue-refiner refines plan
+    HumanReview --> Implementation: Human adds "Refined" label
+    Implementation --> InReview: PR created, "In Review" added
+    InReview --> CIFix: CI fails
+    CIFix --> InReview: CI fixed
+    InReview --> ReviewAddressing: Review comments posted
+    ReviewAddressing --> InReview: Comments addressed
+    InReview --> Merged: PR merged
+    Merged --> Implementation: Multi-PR next phase
+    Merged --> [*]: All phases complete
+```
+
+### Text Diagram
+
+For environments where Mermaid is not available:
+
+```
+                          +-------------------+
+                          |   Issue Created   |
+                          +---------+---------+
+                                    |
+                          Add "Needs Refinement"
+                                    |
+                          +---------v---------+
+                          |     Planning      |  <-- issue-refiner generates plan
+                          +---------+---------+
+                                    |
+                    +---------------+---------------+
+                    |                               |
+            plan-reviewer               plan-reviewer
+              enabled                     disabled
+                    |                               |
+          +---------v---------+                     |
+          |   Plan Review     |                     |
+          +---------+---------+                     |
+                    |                               |
+            Review posted,                          |
+            "Ready" added                           |
+                    |                               |
+                    +---------------+---------------+
+                                    |
+                          +---------v---------+
+                  +------>|   Human Review    |  <-- "Ready" label
+                  |       +---------+---------+
+                  |                 |
+                  |       +---------+---------+
+                  |       |                   |
+                  |   Human posts         Human adds
+                  |   feedback             "Refined"
+                  |       |                   |
+          +-------+-------+         +--------v--------+
+          |   Feedback    |         |  Implementation  |  <-- issue-worker
+          +---------------+         +--------+--------+
+                                             |
+                                    PR created,
+                                    "In Review" added
+                                             |
+                                    +--------v--------+
+                              +---->|    In Review     |<----+
+                              |     +--------+--------+     |
+                              |              |              |
+                         CI fixed      +-----+-----+   Comments
+                              |        |           |   addressed
+                     +--------+--+  CI fails   Review    +--+--------+
+                     |   CI Fix  |     |      comments   | Addressing |
+                     +-----------+  +--v---+   posted  +-+-----------+
+                                    |CI Fix|     |
+                                    +------+  +--v-----------+
+                                              | Addressing   |
+                                              +--------------+
+                                             |
+                                        PR merged
+                                             |
+                                    +--------v--------+
+                                    |     Merged      |
+                                    +--------+--------+
+                                             |
+                                    +--------+--------+
+                                    |                 |
+                              Multi-PR          All phases
+                              next phase         complete
+                                    |                 |
+                              (back to            Issue
+                            Implementation)      closed
+```
+
+---
+
+## Transitions in Detail
+
+### 1. Issue Creation to Planning
+
+**Trigger:** A human adds the `Needs Refinement` label to an issue.
+
+**What happens:** The [issue-refiner](jobs/issue-refiner.md) picks up the issue on its next poll cycle. It creates an isolated git worktree, feeds the issue body and comments to Claude, and asks for a detailed implementation plan.
+
+**Labels:** `Needs Refinement` is present at start.
+
+**Comments posted:** An `## Implementation Plan` comment appears on the issue.
+
+### 2. Planning (issue-refiner)
+
+**Job:** [issue-refiner](jobs/issue-refiner.md)
+
+The refiner reads the issue, any existing comments, and the repository's `yeti/OVERVIEW.md` documentation. Claude produces a plan covering which files to change, what the changes should be, risks, edge cases, and implementation order.
+
+**Label transitions:**
+
+- Removes `Needs Refinement`
+- Adds `Needs Plan Review` (if plan-reviewer is enabled) **or** `Ready` (if disabled)
+
+For `[ci-unrelated]` issues, the refiner also auto-adds `Refined` to skip human approval entirely.
+
+### 3. Plan Review (plan-reviewer, optional)
+
+**Job:** [plan-reviewer](jobs/plan-reviewer.md)
+
+When enabled, the plan-reviewer acts as an adversarial critic. It reads the plan and the issue, then posts a `## Plan Review` comment highlighting gaps, risks, edge cases, and over-engineering concerns.
+
+The review is written for the **human**, not for automatic AI refinement. The intent is to give you a second opinion before you approve the plan.
+
+**Label transitions:**
+
+- Removes `Needs Plan Review`
+- Adds `Ready`
+
+### 4. Human Review (Ready state)
+
+**Label:** `Ready`
+
+The ball is in your court. The issue now has:
+
+- An implementation plan (from issue-refiner)
+- Optionally, a plan review (from plan-reviewer)
+
+You have two choices:
+
+- **Approve:** Add the `Refined` label to greenlight implementation.
+- **Request changes:** Post a comment with feedback. The issue-refiner will pick up your comments on its next cycle and refine the plan.
+
+### 5. Feedback Loop
+
+**Job:** [issue-refiner](jobs/issue-refiner.md)
+
+When you post comments after the plan, the issue-refiner detects unreacted human comments and enters refinement mode. It updates the existing plan comment in-place (rather than posting a new one) and reacts with a thumbsup to each feedback comment it has addressed.
+
+**Label transitions:**
+
+- Removes `Ready` (while processing feedback)
+- Re-adds `Needs Plan Review` or `Ready` (after updated plan is posted)
+
+This cycle continues until you are satisfied and add `Refined`.
+
+### 6. Implementation (issue-worker)
+
+**Job:** [issue-worker](jobs/issue-worker.md)
+
+**Trigger:** `Refined` label on an issue.
+
+The worker creates a worktree on branch `yeti/issue-<number>-<hex4>`, runs Claude with the plan, and opens a PR.
+
+**PR titles:**
+
+- Single PR: `fix: resolve #N -- <title>`
+- Multi-PR phase: `fix(#N): <phase title> (M/total)`
+
+**PR bodies:**
+
+- Single PR: Description + `Closes #N`
+- Intermediate phase: Description + `Part of #N`
+- Final phase: Description + `Closes #N`
+
+**Label transitions:**
+
+- Removes `Refined`
+- Removes `Ready`
+- Adds `In Review` to the source issue
+
+**Guards:**
+
+- Checks for existing open PR for the issue (skips if found)
+- Tree-diff guard: only pushes if there are both new commits and actual tree differences
+- Fresh duplicate-PR guard: bypasses the PR list cache to avoid race conditions
+
+### 7. CI Fixing (ci-fixer)
+
+**Job:** [ci-fixer](jobs/ci-fixer.md)
+
+Automatically watches all open Yeti PRs for:
+
+- **Merge conflicts:** Merges the base branch and uses Claude to resolve conflicts
+- **Cancelled checks:** Re-runs the GitHub Actions workflow
+- **Unrelated failures:** Files a `[ci-unrelated]` issue, reverts previous fix attempts, merges the base branch
+- **Related failures:** Uses Claude to analyze logs and fix the code
+
+After fixing, the ci-fixer updates the PR description to reflect the changes.
+
+### 8. Review Addressing (review-addresser)
+
+**Job:** [review-addresser](jobs/review-addresser.md)
+
+When review comments appear on a Yeti PR, the review-addresser picks them up. It runs Claude to make code changes or post text responses, pushes any changes, and reacts with a thumbsup to each addressed comment.
+
+**Label transitions:**
+
+- Adds `Ready` to the PR after addressing comments (signals that the PR needs another look)
+
+### 9. Auto-merge (auto-merger)
+
+**Job:** [auto-merger](jobs/auto-merger.md)
+
+Watches for PRs that meet merge criteria and squash-merges them automatically. No AI is needed for this job.
+
+**Label transitions:**
+
+- Removes `In Review` from the source issue after merging a `yeti/issue-*` PR
+
+### 10. Multi-PR Phases
+
+For large issues where the plan specifies multiple PRs, Yeti handles them sequentially:
+
+1. The issue-worker creates the first PR.
+2. When that PR is merged, the issue-worker detects that more phases remain.
+3. It re-adds the `Refined` label to the issue, triggering the next phase.
+4. A progress comment is posted on the issue summarizing completed phases.
+5. The cycle repeats until all phases are complete, at which point the final PR's body contains `Closes #N`.
+
+---
+
+## Special Cases
+
+### [ci-unrelated] Issues
+
+Issues with titles starting with `[ci-unrelated]` are created by the ci-fixer when it identifies CI failures unrelated to PR changes (flakey tests, runner issues, pre-existing failures).
+
+These issues follow a shortened lifecycle:
+
+1. The issue-refiner processes them **without** requiring the `Needs Refinement` label.
+2. After posting the plan, the refiner auto-adds `Refined` (skipping human approval).
+3. The issue-worker implements the fix as a normal PR.
+
+### [yeti-error] Issues
+
+Issues with titles matching `[yeti-error] <fingerprint>` are Yeti's own error reports. They require triage before planning:
+
+1. The [triage-yeti-errors](jobs/triage-yeti-errors.md) job investigates the error and posts a `## Yeti Error Investigation Report`.
+2. Only after the report is posted will the issue-refiner consider the issue for planning.
+3. The issue-refiner then requires the `Needs Refinement` label (same as regular issues).
+
+### Dependabot PRs
+
+Dependabot PRs are auto-merged by the [auto-merger](jobs/auto-merger.md) when all checks pass. No issue or plan is needed.
+
+### Doc PRs (yeti/docs-*)
+
+Documentation PRs created by the [doc-maintainer](jobs/doc-maintainer.md) are auto-merged when:
+
+- All changed files are under `yeti/` or end in `.md`
+- Checks pass **or** no checks are configured

--- a/site/stylesheets/extra.css
+++ b/site/stylesheets/extra.css
@@ -1,0 +1,41 @@
+/* Frostyard — light snow accents */
+
+:root {
+  --frost-soft: #e8f4f8;
+  --frost-accent: #b3dce8;
+  --frost-border: #cce7f0;
+}
+
+[data-md-color-scheme="slate"] {
+  --frost-soft: #1a2a33;
+  --frost-accent: #2d4a5a;
+  --frost-border: #3a5a6a;
+}
+
+/* Subtle frost tint on admonitions */
+.md-typeset .admonition.tip,
+.md-typeset details.tip {
+  border-color: var(--frost-accent);
+}
+
+/* Frost-tinted code blocks */
+.md-typeset code {
+  background-color: var(--frost-soft);
+}
+
+[data-md-color-scheme="slate"] .md-typeset code {
+  background-color: var(--frost-soft);
+}
+
+/* Snowflake separator — used via <div class="frost-divider"></div> */
+.frost-divider {
+  text-align: center;
+  margin: 2rem 0;
+  color: var(--frost-accent);
+  font-size: 1.2rem;
+  letter-spacing: 0.5em;
+}
+
+.frost-divider::before {
+  content: "* * *";
+}

--- a/site/usage/daily-workflow.md
+++ b/site/usage/daily-workflow.md
@@ -1,0 +1,91 @@
+# Daily Workflow
+
+Yeti keeps a steady rhythm in the background. Your job is to steer --- decide what gets built, review the plans, and approve the results. Yeti handles the rest, quietly working through your backlog like something that thrives in conditions others would rather avoid.
+
+## Your role
+
+You manage two things: **issues** and **reviews**. Yeti handles everything in between.
+
+The division is simple. You make decisions. Yeti executes them. Labels are how you communicate what you want --- a lightweight signaling system that keeps the whole operation moving without meetings, standups, or Slack threads.
+
+## The typical cycle
+
+### 1. An issue appears
+
+Either you create one manually, or Yeti surfaces improvements on its own via the `improvement-identifier` job. Either way, it starts as a normal GitHub issue.
+
+### 2. Label it for planning
+
+Add the **Needs Refinement** label. This tells Yeti to read the codebase, understand the issue, and draft a plan.
+
+### 3. Yeti posts a plan
+
+Within the next polling interval, Yeti posts an **## Implementation Plan** comment on the issue. This is a structured breakdown: which files to touch, what to change, how to verify it works.
+
+If `plan-reviewer` is enabled, Yeti also posts a **## Plan Review** --- an adversarial critique of its own plan. Think of it as a second opinion that arrives before you even ask.
+
+Yeti adds the **Ready** label. The trail is yours now.
+
+### 4. You review the plan
+
+Read the implementation plan. You have two options:
+
+- **Approve it.** Add the **Refined** label. Yeti picks it up and starts implementation.
+- **Request changes.** Post a comment with your feedback. Yeti will incorporate your notes and generate a revised plan on the next cycle.
+
+This is the most important checkpoint in the whole workflow. A good plan produces a good PR. Take the time to read it.
+
+### 5. Yeti implements
+
+Once an issue has the **Refined** label, the `issue-worker` job creates a fresh worktree, generates the implementation, and opens a pull request. Yeti adds the **In Review** label to the issue so you know a PR is out.
+
+### 6. You review the PR
+
+Review the pull request as you normally would. Leave comments, request changes, approve --- the usual flow.
+
+If you leave review comments, the `review-addresser` job picks them up and pushes new commits to address them. No need to ping anyone or wait for a response.
+
+### 7. It merges
+
+If `auto-merger` is enabled and the PR meets all criteria (CI passing, approvals present, no unresolved threads), it merges automatically. Otherwise, merge it yourself when you are satisfied.
+
+The issue closes. The backlog gets a little shorter.
+
+---
+
+## Multi-PR issues
+
+Some issues are too large for a single pull request. Yeti handles these by breaking the work into phased PRs --- Part 1/3, Part 2/3, and so on.
+
+Each phase is a separate PR. When one phase merges, Yeti re-labels the issue as **Refined** to kick off the next phase. You review each phase independently, but you only had to approve the plan once.
+
+---
+
+## Background jobs
+
+Several jobs run on their own schedules without needing your attention. They are the cold-weather maintenance crew:
+
+| Job | What it does | Schedule |
+|---|---|---|
+| **ci-fixer** | Reads CI failure logs and pushes fixes. Also resolves merge conflicts. | Every 5 minutes |
+| **doc-maintainer** | Updates project documentation to reflect code changes | Nightly |
+| **repo-standards** | Syncs Yeti's label set to all watched repositories | Daily |
+| **issue-auditor** | Audits label state across repos, reports anomalies via Discord | Nightly |
+| **triage-yeti-errors** | Investigates Yeti's own `[yeti-error]` issues and triages them | Every 5 minutes |
+| **improvement-identifier** | Scans codebases for potential improvements and creates issues | Daily |
+
+You do not need to interact with these directly. They run, they report, they keep things tidy. Check the dashboard logs if you want to see what they have been up to.
+
+---
+
+## A typical day
+
+A productive day with Yeti looks something like this:
+
+1. **Morning** --- Open the dashboard. Check the queue page for items marked "Human attention." These are plans waiting for your review.
+2. **Review plans** --- Read the implementation plans Yeti posted overnight. Approve the good ones with the **Refined** label. Leave feedback on any that need adjustment.
+3. **Review PRs** --- Check open PRs that Yeti created. Review the code, leave comments if needed. Yeti addresses them.
+4. **Create new issues** --- File issues for things you want done. Label them **Needs Refinement** when you are ready for Yeti to plan them.
+5. **End of day** --- Merge anything that looks good. Yeti keeps working through the night, and you will have fresh plans and PRs waiting in the morning.
+
+The rhythm settles in quickly. You spend your time on decisions --- what to build, whether the approach is right, whether the code is good --- and Yeti handles the mechanical work of planning, implementing, and shepherding changes through your pipeline.

--- a/site/usage/dashboard.md
+++ b/site/usage/dashboard.md
@@ -1,0 +1,120 @@
+# Dashboard
+
+Yeti's web dashboard gives you a real-time view of everything the daemon is doing. It runs at `http://localhost:9384` by default --- a warm outpost where you can monitor all the activity happening across your repositories.
+
+## Authentication
+
+If you set `authToken` in your config, the dashboard requires authentication. Pass your token as a query parameter:
+
+```
+http://localhost:9384?token=your-secret-token
+```
+
+Without an `authToken` configured, the dashboard is open to anyone who can reach the port. This is fine on private networks or behind a reverse proxy with its own auth layer.
+
+## Main page
+
+The root page (`/`) is your command center. It shows every registered job with:
+
+| Column | Description |
+|---|---|
+| **Job name** | The job identifier (e.g., `issue-refiner`, `ci-fixer`) |
+| **Status** | Current state: idle, running, or paused |
+| **Last run** | When the job last executed, with duration |
+| **Next run** | Countdown to the next scheduled execution |
+
+### Controls
+
+Each job has action buttons:
+
+- **Trigger** --- Run the job immediately, regardless of its schedule. Useful when you have just labeled an issue and do not want to wait for the next polling interval.
+- **Pause / Resume** --- Temporarily stop a job from running on its schedule. The job stays registered but skips its intervals until resumed.
+- **Cancel** --- Abort a currently running Claude task. Sends SIGTERM to the AI process, with SIGKILL escalation if it does not stop gracefully.
+
+## Queue page
+
+The queue page (`/queue`) shows all labeled issues and PRs across your watched repositories, organized into two categories that make it clear who needs to act next.
+
+### Human attention
+
+Items waiting on you. These have the **Ready** label --- Yeti has done its part and is waiting for your decision:
+
+- Plans ready for review (approve with **Refined** or post feedback)
+- Any item that needs a human judgment call
+
+### Yeti attention
+
+Items Yeti will process on its next cycle. These are in various stages of the pipeline:
+
+| State | Meaning |
+|---|---|
+| Needs Refinement | Waiting for issue-refiner to generate a plan |
+| Refined | Waiting for issue-worker to implement |
+| Needs Review Addressing | PR has unaddressed review comments |
+| Auto-mergeable | PR meets merge criteria, waiting for auto-merger |
+| Needs Triage | Error issue waiting for triage |
+| Needs Plan Review | Plan waiting for adversarial review |
+
+### Item details
+
+Each queue item shows:
+
+- **Repository** name
+- **Issue or PR number** and title
+- **Current labels**
+
+### Actions
+
+For items in the queue, you can:
+
+- **Merge** --- For PRs that are ready, trigger a squash merge directly from the dashboard
+- **Skip** --- Tell Yeti to ignore this item (persisted in config)
+- **Prioritize** --- Move this item to the front of all processing queues
+
+## Logs page
+
+The logs page (`/logs`) is where you go to understand what Yeti has been doing --- and what went wrong when something did.
+
+### Filtering
+
+Narrow down the log list by:
+
+- **Job name** --- Show runs for a specific job only
+- **Status** --- Filter by success or failure
+- **Search text** --- Free-text search across log output
+
+### Log entries
+
+Each entry shows:
+
+| Field | Description |
+|---|---|
+| **Job** | Which job produced this log |
+| **Timestamp** | When the run started |
+| **Duration** | How long it took |
+| **Status** | Success or failed |
+
+Click into any entry to see the full log output --- every line the job produced during that run.
+
+### Issue-specific view
+
+You can also view all log entries related to a specific issue. This is useful when you want to trace the full history of how Yeti processed a particular item: the refinement run, the implementation run, any CI fix attempts, and review addressing.
+
+## Config page
+
+The config page (`/config`) lets you view and edit Yeti's configuration directly from the browser.
+
+- **View** --- All current configuration values are displayed. Sensitive fields like tokens are masked.
+- **Edit** --- Modify `config.json` in-place. Changes are saved to disk and trigger a live reload --- no restart needed for most fields.
+
+See the [Configuration](../getting-started/configuration.md) guide for details on which fields reload live and which require a restart.
+
+## Themes
+
+The dashboard supports three display modes:
+
+- **Light** --- Clean and bright, for those rare sunny days
+- **Dark** --- Easy on the eyes during long sessions or late-night monitoring
+- **System** --- Follows your OS preference automatically
+
+Toggle between them from the dashboard header.

--- a/site/usage/discord.md
+++ b/site/usage/discord.md
@@ -1,0 +1,99 @@
+# Discord Bot
+
+Yeti's Discord integration lets you manage issues, analyze work, and receive notifications without leaving your chat. It is entirely optional --- Yeti runs fine without it --- but if Discord is where your team already lives, it keeps everything within arm's reach.
+
+## Setup
+
+Three config fields activate the bot:
+
+```json
+{
+  "discordBotToken": "your-bot-token",
+  "discordChannelId": "123456789012345678",
+  "discordAllowedUsers": ["your-discord-user-id"]
+}
+```
+
+| Field | Description |
+|---|---|
+| `discordBotToken` | Bot token from the Discord developer portal |
+| `discordChannelId` | Channel where Yeti posts notifications and listens for commands |
+| `discordAllowedUsers` | Array of Discord user IDs permitted to run commands |
+
+### Creating the bot
+
+1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Create a new application and add a bot
+3. Enable the following **Privileged Gateway Intents**:
+    - Guilds
+    - Guild Messages
+    - Message Content
+4. Generate an invite URL with the `bot` scope and `Send Messages` + `Read Message History` permissions
+5. Invite the bot to your server
+6. Copy the bot token into your Yeti config
+
+!!! note
+    The Discord bot connects at startup. Changes to `discordBotToken` or `discordChannelId` require a service restart to take effect. The `discordAllowedUsers` list reloads live.
+
+## Notifications
+
+Yeti posts to your configured channel automatically. You do not need to set anything up beyond the bot itself --- notifications flow as part of normal job activity.
+
+**What Yeti reports:**
+
+- **Issue audit summaries** --- The `issue-auditor` job posts its nightly findings: mislabeled issues, stale items, anomalies across your repos
+- **Error reports** --- When something goes wrong, the error reporter sends a summary with deduplication (the same error will not flood your channel)
+- **Job activity** --- Completion notifications for significant work
+
+Notifications are informational. They do not require a response --- just a glance to confirm things are running smoothly, like checking the weather before heading out.
+
+## Commands
+
+All commands use the `!yeti` prefix. Only users listed in `discordAllowedUsers` can run them.
+
+### `!yeti help`
+
+Shows the list of available commands.
+
+### `!yeti issue <repo> <title> [body]`
+
+Create a GitHub issue from Discord.
+
+```
+!yeti issue frontend Add dark mode toggle
+
+The settings page needs a dark/light mode switch.
+Users have been requesting this in the feedback channel.
+```
+
+The first line after the repo name becomes the title. Everything after the first line break becomes the issue body.
+
+**Repo names are short names** scoped to your configured GitHub org. Use `frontend`, not `your-org/frontend`.
+
+### `!yeti look <repo> <issue-number>`
+
+Analyze an issue or PR with Claude and get a summary posted back to Discord.
+
+```
+!yeti look api 42
+```
+
+Yeti reads the issue, its comments, and the relevant codebase context, then posts an analysis. Useful when you want a quick read on something without opening GitHub.
+
+### `!yeti assign <repo> <issue-number>`
+
+Label an issue as **Refined**, which tells Yeti to start implementation.
+
+```
+!yeti assign frontend 15
+```
+
+This is the Discord equivalent of adding the **Refined** label on GitHub. Use it when you have already reviewed the plan and want to greenlight implementation from your chat.
+
+## Permissions
+
+Only Discord users whose IDs appear in the `discordAllowedUsers` config array can execute commands. Messages from other users are silently ignored.
+
+To find a Discord user ID: enable Developer Mode in Discord settings, then right-click your username and select "Copy User ID."
+
+The `discordAllowedUsers` list reloads live --- you can grant or revoke access without restarting Yeti.

--- a/site/usage/optimization.md
+++ b/site/usage/optimization.md
@@ -1,0 +1,250 @@
+# Optimization
+
+Yeti runs standard `claude` and `copilot` CLI sessions inside your repository. Every job that calls AI spawns a real CLI process in a git worktree of your repo --- the same process you'd get if you opened a terminal, `cd`'d into your project, and ran `claude` yourself.
+
+This means **all your existing agent configuration applies**. CLAUDE.md files, skills, hooks, settings --- Yeti's AI reads and follows them just like an interactive session would. The quality of Yeti's plans, implementations, and fixes is directly tied to how well your repository is set up for AI agents.
+
+If Yeti is producing mediocre results, the fix is almost never in Yeti's configuration. It's in your repo.
+
+---
+
+## How Yeti invokes AI
+
+When a job needs AI, Yeti:
+
+1. Creates a git worktree of your repo at `~/.yeti/worktrees/<owner>/<repo>/<job>/<branch>`
+2. Spawns the CLI in that worktree's root directory
+3. Pipes the job-specific prompt (issue context, CI logs, review comments, etc.) to the process
+4. Collects the output and any file changes
+
+The exact invocations:
+
+```
+# Claude backend
+claude -p --dangerously-skip-permissions
+
+# Copilot backend
+copilot --allow-all-tools -s --no-ask-user -p "<prompt>"
+```
+
+Both run with full filesystem access in your repo's worktree. The CLI loads whatever configuration it finds there --- exactly as it would in an interactive session.
+
+---
+
+## CLAUDE.md
+
+The single most impactful optimization. Claude reads `CLAUDE.md` at the root of your repository before doing anything. This is where you tell the AI how your project works.
+
+A well-written `CLAUDE.md` transforms Yeti's output from generic to project-aware. Without it, Claude is guessing at your conventions. With it, Claude follows your patterns.
+
+### What to include
+
+**Build and test commands** --- Claude needs to know how to verify its work:
+
+```markdown
+## Build & Test
+
+npm ci                    # install dependencies
+npm run build             # compile TypeScript
+npm test                  # run all tests
+npm run lint              # check formatting
+```
+
+**Architecture context** --- how the codebase is organized:
+
+```markdown
+## Architecture
+
+This is a Next.js app with a PostgreSQL backend.
+- `src/app/` — Next.js app router pages
+- `src/lib/` — Shared utilities and database clients
+- `src/components/` — React components (use shadcn/ui)
+- `prisma/` — Database schema and migrations
+```
+
+**Conventions and standards** --- patterns Claude should follow:
+
+```markdown
+## Conventions
+
+- Use `snake_case` for database columns, `camelCase` for TypeScript
+- All API routes return `{ data, error }` envelope
+- Components use CSS modules, not Tailwind
+- Tests are co-located: `foo.test.ts` next to `foo.ts`
+- Never use `any` — use `unknown` and narrow
+```
+
+**What NOT to do** --- guard rails are just as important as guidance:
+
+```markdown
+## Do not
+
+- Do not modify migration files after they've been committed
+- Do not add new npm dependencies without checking for existing alternatives
+- Do not use default exports
+```
+
+### CLAUDE.md placement
+
+Claude supports hierarchical instructions:
+
+| File | Scope |
+|------|-------|
+| `CLAUDE.md` (repo root) | Applies to all work in the repo |
+| `src/CLAUDE.md` | Applies when working in `src/` |
+| `src/api/CLAUDE.md` | Applies when working in `src/api/` |
+| `~/.claude/CLAUDE.md` | Your global instructions (all repos) |
+
+Yeti's worktrees are full clones, so nested CLAUDE.md files work as expected. Use them to give specific guidance for specific parts of your codebase --- the API layer might have different conventions than the frontend.
+
+---
+
+## Copilot instructions
+
+If you route jobs to the Copilot backend via `jobAi`, the equivalent configuration files are:
+
+| File | Purpose |
+|------|---------|
+| `.github/copilot-instructions.md` | Repository-level instructions for Copilot |
+| `AGENTS.md` | Agent-mode instructions (similar to CLAUDE.md) |
+
+These files serve the same role as CLAUDE.md but for the Copilot CLI. If you're using both backends (e.g., Claude for implementation, Copilot for plan review), maintain both instruction files.
+
+---
+
+## Skills
+
+Skills are reusable instruction sets that the Claude CLI loads on demand. They're especially powerful for Yeti because they can encode your team's processes --- coding standards, testing patterns, review criteria --- in a way that applies automatically to every AI task.
+
+### Repository skills
+
+Place skill files in `.claude/skills/` in your repo:
+
+```
+.claude/skills/
+├── testing.md          # How to write tests in this project
+├── api-design.md       # API conventions and patterns
+└── database.md         # Migration and query patterns
+```
+
+Each skill file has frontmatter that tells Claude when to activate it:
+
+```markdown
+---
+name: testing
+description: Testing conventions for this project
+---
+
+## Testing Rules
+
+- Use vitest, not jest
+- Mock external boundaries only (HTTP, filesystem, database)
+- Use factory functions from `src/test-helpers.ts` for test data
+- Every new function needs at least one happy-path and one error test
+- Integration tests go in `__tests__/integration/`
+```
+
+When Yeti's issue-worker implements a feature, Claude sees these skills and follows them. When the ci-fixer repairs a broken test, it knows your testing conventions. When the review-addresser responds to "add tests for this," it knows *how* you test.
+
+### Global skills
+
+Skills in `~/.claude/skills/` apply to all repos. Use these for cross-project standards --- your organization's coding style, security requirements, or documentation patterns.
+
+---
+
+## Hooks
+
+Hooks are shell commands that run before or after Claude takes specific actions. They're configured in `.claude/settings.json` (per-repo) or `~/.claude/settings.json` (global).
+
+Common uses for Yeti optimization:
+
+**Auto-format after edits:**
+
+```json
+{
+  "hooks": {
+    "postToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": "npx prettier --write $FILE_PATH"
+      }
+    ]
+  }
+}
+```
+
+**Lint check before commit:**
+
+```json
+{
+  "hooks": {
+    "preToolUse": [
+      {
+        "matcher": "Bash",
+        "command": "echo 'run npm run lint before committing'"
+      }
+    ]
+  }
+}
+```
+
+Since Yeti runs Claude with `--dangerously-skip-permissions`, hooks execute without prompts. Make sure your hooks are safe for unattended execution.
+
+---
+
+## yeti/OVERVIEW.md
+
+Several Yeti jobs explicitly instruct the AI to read `yeti/OVERVIEW.md` before starting work. This file is maintained by the [doc-maintainer](../reference/jobs/doc-maintainer.md) job and serves as a comprehensive architecture guide written for AI consumption.
+
+While CLAUDE.md gives *instructions* (do this, don't do that), `yeti/OVERVIEW.md` gives *context* (how the system works, why decisions were made, where things live). Both matter:
+
+| File | Purpose | Audience | Maintained by |
+|------|---------|----------|---------------|
+| `CLAUDE.md` | Instructions and conventions | Claude CLI | You |
+| `yeti/OVERVIEW.md` | Architecture and context | Yeti jobs | doc-maintainer (AI) |
+
+If you don't have a `yeti/OVERVIEW.md`, the doc-maintainer job will create one. If the generated overview is inaccurate, edit it --- the doc-maintainer will preserve your manual changes and build on them in future updates.
+
+You can also create additional docs under `yeti/` and link them from `OVERVIEW.md`. The doc-maintainer and issue-refiner will follow those links.
+
+---
+
+## .claude/settings.json
+
+Per-repository settings that control Claude's tool permissions and behavior. Since Yeti runs with `--dangerously-skip-permissions`, most permission settings are bypassed --- but the file is still read for other configuration like hooks and MCP servers.
+
+---
+
+## Optimization checklist
+
+Start here if Yeti's output quality isn't where you want it:
+
+- [ ] **CLAUDE.md exists** with build commands, architecture overview, and conventions
+- [ ] **Build/test commands work** --- if Claude can't verify its changes, quality drops
+- [ ] **Conventions are explicit** --- don't assume Claude knows your patterns; spell them out
+- [ ] **Guard rails are set** --- list things Claude should never do
+- [ ] **yeti/OVERVIEW.md exists** --- run doc-maintainer once to bootstrap it, then refine
+- [ ] **Skills cover complex patterns** --- testing, API design, database work
+- [ ] **Copilot instructions match** (if using Copilot backend) --- `.github/copilot-instructions.md` and/or `AGENTS.md`
+
+The repos that get the best results from Yeti are the ones that would also get the best results from a new human contributor: clear instructions, documented patterns, and fast feedback loops via CI.
+
+---
+
+## Per-job tuning
+
+Beyond repo-level configuration, you can tune individual jobs via `jobAi` in Yeti's config:
+
+```json
+{
+  "jobAi": {
+    "plan-reviewer": { "backend": "copilot" },
+    "issue-refiner": { "model": "opus" },
+    "issue-worker": { "model": "sonnet" }
+  }
+}
+```
+
+This lets you route different jobs to different backends or models. A common pattern: use a stronger model for planning (where reasoning matters most) and a faster model for implementation (where the plan provides sufficient guidance). Or use a different backend entirely for plan review, so the reviewer has a genuinely different perspective from the planner.
+
+See the [configuration reference](../reference/configuration.md) for details on `jobAi`.

--- a/site/usage/queue-management.md
+++ b/site/usage/queue-management.md
@@ -1,0 +1,116 @@
+# Queue Management
+
+The queue is where all of Yeti's pending work lives. Understanding how to manage it gives you fine-grained control over what gets processed, in what order, and what gets left alone.
+
+## The queue page
+
+Navigate to `/queue` on the dashboard. The page shows every labeled issue and PR across your watched repositories, sorted into categories by state. At a glance, you can see what is waiting on you, what Yeti is about to pick up, and what is frozen in place.
+
+For details on the queue page layout, see the [Dashboard](dashboard.md) guide.
+
+## Skipping items
+
+Sometimes an issue should not be automated. Maybe it requires manual work, or you want to pause Yeti's involvement while you think through the approach. Skipping is how you tell Yeti to leave something alone.
+
+**To skip an item:** Click the Skip button next to it on the queue page.
+
+**What happens:**
+
+- The item's identifier is added to the `skippedItems` array in `config.json`
+- All jobs ignore skipped items during processing
+- The item still appears on the queue page, marked as skipped
+- Labels on GitHub are not affected --- skipping is a Yeti-side control
+
+**To unskip:** Click the Unskip button. The item is removed from `skippedItems` and becomes eligible for processing again.
+
+**When to skip:**
+
+- An issue requires human implementation, not AI
+- You want to temporarily shelve something without removing its labels
+- A PR needs manual intervention that Yeti keeps trying to "fix"
+- An item is causing repeated failures and you want Yeti to move on
+
+Skipped items persist across restarts. They stay skipped until you explicitly unskip them.
+
+## Prioritizing items
+
+When something needs to jump the queue, mark it as priority. Priority items are processed before everything else, across all jobs.
+
+**To prioritize:** Click the Prioritize button on the queue page.
+
+**What happens:**
+
+- The item is added to the `prioritizedItems` array in `config.json`
+- The **Priority** label is synced to the issue on GitHub
+- All jobs process priority items first, before working through the regular queue
+- The item appears highlighted on the queue page
+
+**To remove priority:** Click the button again to deprioritize. The item returns to normal queue ordering.
+
+Priority is useful for urgent fixes, high-value features, or anything that should not wait its turn in the cold.
+
+## Merging from the queue
+
+For pull requests that are ready to land, you can merge directly from the queue page without opening GitHub.
+
+**To merge:** Click the Merge button next to an eligible PR.
+
+Yeti performs a **squash merge**, combining all commits into a single clean commit on the target branch. This is the same merge strategy the `auto-merger` job uses.
+
+!!! tip
+    The Merge button only appears for PRs that have passing CI checks. If a PR's checks are still running or have failed, the button will not be available.
+
+## Config-level controls
+
+Beyond per-item skip and priority, several config fields give you broader control over what Yeti works on.
+
+### `allowedRepos`
+
+Limit which repositories Yeti scans. When set, only the listed repos are processed. When `null` or omitted, Yeti watches everything under your configured GitHub owners.
+
+```json
+"allowedRepos": ["frontend", "api"]
+```
+
+Use this to start small --- watch one or two repos until you are comfortable with the workflow, then expand.
+
+### `pausedJobs`
+
+Pause specific jobs without disabling them entirely. Paused jobs stay registered and visible on the dashboard but skip their scheduled runs.
+
+```json
+"pausedJobs": ["improvement-identifier", "doc-maintainer"]
+```
+
+Pausing is lighter than removing a job from `enabledJobs`. The job keeps its schedule and state --- it just does not fire until you resume it (from config or the dashboard).
+
+### `enabledJobs`
+
+The master switch. Only jobs listed here will run. An empty array means Yeti sits idle, patiently waiting for instructions.
+
+```json
+"enabledJobs": [
+  "issue-refiner",
+  "issue-worker",
+  "ci-fixer",
+  "review-addresser",
+  "auto-merger",
+  "repo-standards"
+]
+```
+
+See the [Configuration](../getting-started/configuration.md) guide for the full list of available jobs.
+
+---
+
+## Putting it together
+
+A practical approach to queue management:
+
+1. **Start narrow.** Set `allowedRepos` to one or two repos. Enable just the core jobs.
+2. **Watch the queue.** Get comfortable with the rhythm of items flowing through states.
+3. **Skip liberally.** If something does not feel right for automation, skip it. You can always unskip later.
+4. **Prioritize sparingly.** If everything is priority, nothing is. Reserve it for genuinely urgent items.
+5. **Expand gradually.** Add repos and jobs as you build confidence in the workflow.
+
+Yeti is patient. It will process your backlog at whatever pace you set, steadily working through the queue like snowfall accumulating overnight --- quietly, consistently, and without complaint.

--- a/site/usage/troubleshooting.md
+++ b/site/usage/troubleshooting.md
@@ -1,0 +1,200 @@
+# Troubleshooting
+
+When things go sideways in the cold, start here.
+
+---
+
+## Yeti won't start
+
+**Check the service status:**
+
+```bash
+systemctl status yeti
+journalctl -u yeti -n 50 --no-pager
+```
+
+**Common causes:**
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `ERR_MODULE_NOT_FOUND` | Missing dependencies | Run `npm ci` in `/opt/yeti` |
+| `EADDRINUSE` | Port 9384 already in use | Check for another Yeti process or change `port` in config |
+| `EACCES` on `~/.yeti/` | Permission mismatch | Ensure the systemd user owns `~/.yeti/` |
+| Crash loop | Bad config | Check `~/.yeti/config.json` for syntax errors |
+
+---
+
+## Jobs aren't running
+
+**Nothing is happening at all:**
+
+- Check `enabledJobs` in your config. An empty array means no jobs run. This is the most common oversight.
+- Open the dashboard at `http://localhost:9384` and verify jobs are listed and not paused.
+
+**A specific job isn't picking up work:**
+
+1. Is the job in `enabledJobs`? It must be listed by name.
+2. Is the job paused? Check the dashboard or `pausedJobs` in config.
+3. Is the item in `skippedItems`? Check the queue page.
+4. Is the previous run still active? Jobs use skip-if-busy --- they won't queue up if the last run hasn't finished.
+5. Check the logs page (`/logs`) filtered by that job name for errors.
+
+**Jobs run but produce no output:**
+
+- The AI process may be timing out. Check logs for timeout messages.
+- Increase `claudeTimeoutMs` or `copilotTimeoutMs` if tasks are consistently hitting the 20-minute default.
+
+---
+
+## Issues aren't being planned
+
+**issue-refiner isn't picking up an issue:**
+
+1. Does the issue have the `Needs Refinement` label? Regular issues require it.
+2. Is `issue-refiner` in `enabledJobs`?
+3. Is the repo in `allowedRepos` (or is `allowedRepos` set to `null` for all repos)?
+4. Is the issue in `skippedItems`?
+5. Check `/logs` for the issue-refiner job --- look for errors or "no work found" messages.
+
+**Plan quality is poor:**
+
+This is a repo configuration issue, not a Yeti issue. See the [Optimization](optimization.md) page. The short version: add a `CLAUDE.md` with build commands, architecture overview, and coding conventions.
+
+---
+
+## PRs aren't being created
+
+**issue-worker runs but no PR appears:**
+
+1. **Tree-diff guard:** The worker checks that its changes actually differ from the base branch. If Claude makes no effective changes (empty diff), no PR is created. Check logs for "no tree diff" messages.
+2. **Duplicate PR guard:** If an open PR for the same issue already exists, the worker skips it. Check for existing PRs.
+3. **Claude errors:** The Claude process may have failed. Check the run log for the specific issue.
+
+**PR is created but immediately fails CI:**
+
+- This is normal --- the [ci-fixer](../reference/jobs/ci-fixer.md) will pick it up on its next cycle.
+- If ci-fixer can't fix it, it'll file a `[ci-unrelated]` issue if the failure isn't caused by the PR's changes.
+
+---
+
+## CI fixer isn't working
+
+**ci-fixer runs but doesn't fix failures:**
+
+1. The fixer classifies failures as "related" (caused by PR changes) or "unrelated" (pre-existing). Check the PR comments for its classification.
+2. For related failures, Claude reads the CI logs and attempts a fix. If the logs are too large or unclear, the fix may fail.
+3. For unrelated failures, the fixer files a `[ci-unrelated]` issue rather than attempting a fix on the PR.
+
+**Merge conflicts aren't being resolved:**
+
+- The ci-fixer handles conflicts by merging the base branch and using Claude to resolve markers.
+- If the conflict is too complex, Claude may produce an incorrect resolution. Review the commit.
+
+---
+
+## Auto-merger won't merge
+
+The [auto-merger](../reference/jobs/auto-merger.md) has strict criteria. A PR must match one of these categories:
+
+**Dependabot PRs:**
+
+- All checks must be passing. No exceptions.
+
+**Doc PRs (`yeti/docs-*`):**
+
+- Only `.md` or `yeti/` files can be changed.
+- Checks must pass OR no checks must be configured.
+
+**Issue PRs (`yeti/issue-*`):**
+
+- A valid LGTM comment must exist.
+- The LGTM must be posted *after* the latest commit (stale approvals don't count).
+
+If none of these apply, the PR requires manual merge.
+
+---
+
+## Dashboard issues
+
+**Can't access the dashboard:**
+
+- Verify Yeti is running: `curl localhost:9384/health`
+- If `authToken` is set, you need to log in at `/login`.
+- If accessing remotely, check firewall rules for port 9384.
+
+**Queue shows stale data:**
+
+- The queue is populated by the label scanner, which runs every 5 minutes (`queueScanIntervalMs`).
+- Trigger a manual refresh by visiting `/queue` --- the page fetches fresh data on load.
+- If labels were changed outside Yeti (manually on GitHub), wait for the next scan cycle.
+
+---
+
+## Discord bot not responding
+
+1. Verify `discordBotToken` and `discordChannelId` are set in config.
+2. Check that the bot has the required intents: Guilds, GuildMessages, MessageContent.
+3. Verify your Discord user ID is in `discordAllowedUsers`.
+4. Check Yeti logs for Discord connection errors: `journalctl -u yeti | grep -i discord`
+5. Ensure the bot has permission to read and send messages in the configured channel.
+
+---
+
+## Rate limiting
+
+**GitHub API rate limit errors:**
+
+Yeti uses a circuit breaker with a 60-second cooldown. When rate-limited, all jobs pause API calls for 60 seconds, then resume. This is automatic.
+
+If you're hitting rate limits frequently:
+
+- Increase job intervals to reduce API call frequency.
+- Reduce the number of repos being scanned (`allowedRepos`).
+- Check that `queueScanIntervalMs` isn't set too low.
+
+---
+
+## Auto-updater issues
+
+**Yeti isn't updating:**
+
+```bash
+systemctl status yeti-updater.timer
+systemctl status yeti-updater.service
+journalctl -u yeti-updater -n 20 --no-pager
+```
+
+- The timer checks every 60 seconds.
+- Updates require `gh` CLI to be authenticated as the service user.
+- If a health check fails after update, the updater rolls back automatically.
+
+**Rolled back after update:**
+
+- Check `journalctl -u yeti-updater` for the rollback reason.
+- Usually means the new version's health check (`GET /health`) failed within the timeout window.
+- The previous version is restored and Yeti restarts.
+
+---
+
+## Worktree cleanup
+
+Worktrees are created at `~/.yeti/worktrees/` and cleaned up in `finally` blocks after each job run. On startup, Yeti also cleans up orphaned worktrees from prior crashes.
+
+**If worktrees are accumulating:**
+
+```bash
+ls ~/.yeti/worktrees/*/*/
+```
+
+- Orphaned worktrees usually mean a job crashed without cleanup.
+- Restarting Yeti will trigger crash recovery, which cleans them up.
+- You can safely delete the contents of `~/.yeti/worktrees/` while Yeti is stopped.
+
+---
+
+## Getting more information
+
+- **Dashboard logs:** `/logs` with filtering by job name, status, and search text.
+- **System logs:** `journalctl -u yeti -f` for live tailing.
+- **Health check:** `curl localhost:9384/health` for a quick alive check.
+- **Status endpoint:** `curl localhost:9384/status` for detailed JSON with job schedules, uptime, queue state, and integration status.


### PR DESCRIPTION
## Summary

- Adds a complete MkDocs documentation site (Material theme) with 27 pages in `site/`
- Covers "Why Yeti", installation/configuration/quickstart, daily usage, optimization (CLAUDE.md, skills, hooks), troubleshooting, contributing, and full reference (config fields, labels, issue lifecycle with mermaid diagrams, HTTP API, all 11 jobs)
- Adds `mkdocs.yml` at project root, build output goes to `_site/` (gitignored)
- Light Frostyard snow/cold theming in CSS and prose

## Test plan

- [ ] Run `pip install mkdocs-material && mkdocs serve` and verify all pages render
- [ ] Verify mermaid diagrams render on the Issue Lifecycle page
- [ ] Spot-check cross-references between job pages and labels page
- [ ] Confirm dark/light theme toggle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)