### PR TITLE
fix: resolve #64 — Add mkdocs job

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -76,7 +76,8 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
     "docMaintainerHour": 1,
     "repoStandardsHour": 2,
     "improvementIdentifierHour": 3,
-    "issueAuditorHour": 5
+    "issueAuditorHour": 5,
+    "mkdocsUpdateHour": 4
   },
   "logRetentionDays": 14,
   "logRetentionPerJob": 20,
@@ -90,7 +91,7 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
 CONF
   chmod 600 "$CONFIG_FILE"
   log "Created $CONFIG_FILE — edit it to configure your instance"
-  log "Available jobs for enabledJobs: issue-worker, issue-refiner, ci-fixer, review-addresser, doc-maintainer, auto-merger, repo-standards, improvement-identifier, issue-auditor, triage-yeti-errors, plan-reviewer"
+  log "Available jobs for enabledJobs: issue-worker, issue-refiner, ci-fixer, review-addresser, doc-maintainer, auto-merger, repo-standards, improvement-identifier, issue-auditor, triage-yeti-errors, plan-reviewer, mkdocs-update"
 fi
 
 # Bootstrap env file if it doesn't exist (never overwrite user values)

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,7 @@ export interface ConfigFile {
     repoStandardsHour?: number;
     improvementIdentifierHour?: number;
     issueAuditorHour?: number;
+    mkdocsUpdateHour?: number;
   };
   logRetentionDays?: number;
   logRetentionPerJob?: number;
@@ -117,6 +118,7 @@ function loadConfig() {
     repoStandardsHour: file.schedules?.repoStandardsHour ?? 2, // 2 AM local time
     improvementIdentifierHour: file.schedules?.improvementIdentifierHour ?? 3, // 3 AM local time
     issueAuditorHour: file.schedules?.issueAuditorHour ?? 5, // 5 AM local time
+    mkdocsUpdateHour: file.schedules?.mkdocsUpdateHour ?? 4, // 4 AM local time
   };
 
   const discordBotToken =

--- a/src/jobs/mkdocs-update.test.ts
+++ b/src/jobs/mkdocs-update.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockRepo, mockPR } from "../test-helpers.js";
+
+vi.mock("../config.js", () => ({
+  WORK_DIR: "/home/testuser/.yeti",
+  JOB_AI: {},
+}));
+
+vi.mock("../log.js", () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../error-reporter.js", () => ({
+  reportError: vi.fn(),
+}));
+
+const { mockFs, mockGh, mockClaude, mockDb } = vi.hoisted(() => ({
+  mockFs: {
+    existsSync: vi.fn(),
+  },
+  mockGh: {
+    listPRs: vi.fn(),
+    createPR: vi.fn(),
+  },
+  mockClaude: {
+    createWorktree: vi.fn(),
+    removeWorktree: vi.fn(),
+    enqueue: vi.fn(),
+    enqueueCopilot: vi.fn(),
+    runAI: vi.fn(),
+    hasNewCommits: vi.fn(),
+    hasTreeDiff: vi.fn(),
+    pushBranch: vi.fn(),
+    generateDocsPRDescription: vi.fn(),
+    randomSuffix: vi.fn().mockReturnValue("ab12"),
+    datestamp: vi.fn().mockReturnValue("20260322"),
+  },
+  mockDb: {
+    recordTaskStart: vi.fn().mockReturnValue(1),
+    updateTaskWorktree: vi.fn(),
+    recordTaskComplete: vi.fn(),
+    recordTaskFailed: vi.fn(),
+  },
+}));
+
+vi.mock("node:fs", () => ({ default: mockFs }));
+vi.mock("../github.js", () => mockGh);
+vi.mock("../claude.js", () => mockClaude);
+vi.mock("../db.js", () => mockDb);
+
+import { run } from "./mkdocs-update.js";
+import { reportError } from "../error-reporter.js";
+
+describe("mkdocs-update", () => {
+  const repo = mockRepo();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGh.listPRs.mockResolvedValue([]);
+    mockGh.createPR.mockResolvedValue(100);
+    mockClaude.createWorktree.mockResolvedValue("/tmp/worktree");
+    mockClaude.enqueue.mockImplementation((fn: () => Promise<string>) => fn());
+    mockClaude.enqueueCopilot.mockImplementation((fn: () => Promise<string>) => fn());
+    mockClaude.runAI.mockResolvedValue("docs updated");
+    mockClaude.hasNewCommits.mockResolvedValue(true);
+    mockClaude.hasTreeDiff.mockResolvedValue(true);
+    mockClaude.pushBranch.mockResolvedValue(undefined);
+    mockClaude.removeWorktree.mockResolvedValue(undefined);
+    mockClaude.generateDocsPRDescription.mockResolvedValue("## Summary\nUpdated mkdocs");
+    // Default: mkdocs.yml exists
+    mockFs.existsSync.mockImplementation((p: string) =>
+      String(p).endsWith("mkdocs.yml"),
+    );
+  });
+
+  it("skips repos without mkdocs.yml or mkdocs.yaml", async () => {
+    mockFs.existsSync.mockReturnValue(false);
+
+    await run([repo]);
+
+    expect(mockClaude.runAI).not.toHaveBeenCalled();
+    expect(mockDb.recordTaskComplete).toHaveBeenCalledWith(1);
+    expect(mockClaude.removeWorktree).toHaveBeenCalled();
+  });
+
+  it("detects mkdocs.yaml as alternative extension", async () => {
+    mockFs.existsSync.mockImplementation((p: string) =>
+      String(p).endsWith("mkdocs.yaml"),
+    );
+
+    await run([repo]);
+
+    expect(mockClaude.runAI).toHaveBeenCalled();
+  });
+
+  it("skips repos with existing open mkdocs-update PR", async () => {
+    const pr = mockPR({ headRefName: "yeti/mkdocs-update-20260322-ab12" });
+    mockGh.listPRs.mockResolvedValue([pr]);
+
+    await run([repo]);
+
+    expect(mockClaude.createWorktree).not.toHaveBeenCalled();
+  });
+
+  it("creates PR when Claude produces commits with tree diff", async () => {
+    await run([repo]);
+
+    expect(mockClaude.enqueue).toHaveBeenCalled();
+    expect(mockClaude.runAI).toHaveBeenCalledWith(
+      expect.stringContaining("source code is the single source of truth"),
+      "/tmp/worktree",
+      undefined,
+    );
+    expect(mockClaude.pushBranch).toHaveBeenCalledWith(
+      "/tmp/worktree",
+      expect.stringContaining("yeti/mkdocs-update-"),
+    );
+    expect(mockGh.createPR).toHaveBeenCalledWith(
+      repo.fullName,
+      expect.stringContaining("yeti/mkdocs-update-"),
+      expect.stringContaining("docs:"),
+      "## Summary\nUpdated mkdocs",
+    );
+    expect(mockDb.recordTaskComplete).toHaveBeenCalledWith(1);
+  });
+
+  it("does not create PR when Claude produces no commits", async () => {
+    mockClaude.hasNewCommits.mockResolvedValue(false);
+
+    await run([repo]);
+
+    expect(mockClaude.pushBranch).not.toHaveBeenCalled();
+    expect(mockGh.createPR).not.toHaveBeenCalled();
+  });
+
+  it("does not create PR when commits exist but no tree diff", async () => {
+    mockClaude.hasNewCommits.mockResolvedValue(true);
+    mockClaude.hasTreeDiff.mockResolvedValue(false);
+
+    await run([repo]);
+
+    expect(mockClaude.pushBranch).not.toHaveBeenCalled();
+    expect(mockGh.createPR).not.toHaveBeenCalled();
+  });
+
+  it("cleans up worktree on success", async () => {
+    await run([repo]);
+
+    expect(mockClaude.removeWorktree).toHaveBeenCalledWith(repo, "/tmp/worktree");
+  });
+
+  it("cleans up worktree on error and records task failed", async () => {
+    mockClaude.runAI.mockRejectedValue(new Error("claude crashed"));
+
+    await run([repo]);
+
+    expect(mockClaude.removeWorktree).toHaveBeenCalled();
+    expect(mockDb.recordTaskFailed).toHaveBeenCalledWith(1, expect.stringContaining("claude crashed"));
+  });
+
+  it("reports errors without crashing the loop", async () => {
+    const repo2 = mockRepo({ name: "test-repo-2", fullName: "test-org/test-repo-2" });
+
+    mockClaude.runAI
+      .mockRejectedValueOnce(new Error("first repo error"))
+      .mockResolvedValueOnce("docs updated");
+
+    await run([repo, repo2]);
+
+    expect(reportError).toHaveBeenCalledWith(
+      "mkdocs-update:process-repo",
+      repo.fullName,
+      expect.any(Error),
+    );
+    // Second repo should still be processed
+    expect(mockGh.createPR).toHaveBeenCalledWith(
+      repo2.fullName,
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+    );
+  });
+
+  it("records task tracking lifecycle", async () => {
+    await run([repo]);
+
+    expect(mockDb.recordTaskStart).toHaveBeenCalledWith("mkdocs-update", repo.fullName, 0, null);
+    expect(mockDb.updateTaskWorktree).toHaveBeenCalledWith(1, "/tmp/worktree", expect.stringContaining("yeti/mkdocs-update-"));
+    expect(mockDb.recordTaskComplete).toHaveBeenCalledWith(1);
+  });
+
+  it("uses enqueueCopilot when JOB_AI backend is copilot", async () => {
+    // Re-mock config with copilot backend
+    const configMod = await import("../config.js");
+    Object.defineProperty(configMod, "JOB_AI", {
+      value: { "mkdocs-update": { backend: "copilot" } },
+      writable: true,
+    });
+
+    await run([repo]);
+
+    expect(mockClaude.enqueueCopilot).toHaveBeenCalled();
+
+    // Reset
+    Object.defineProperty(configMod, "JOB_AI", {
+      value: {},
+      writable: true,
+    });
+  });
+});

--- a/src/jobs/mkdocs-update.ts
+++ b/src/jobs/mkdocs-update.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import path from "node:path";
+import { JOB_AI, type Repo } from "../config.js";
+import * as gh from "../github.js";
+import * as claude from "../claude.js";
+import * as log from "../log.js";
+import * as db from "../db.js";
+import { reportError } from "../error-reporter.js";
+
+function buildMkdocsPrompt(fullName: string): string {
+  return [
+    `You are updating MkDocs documentation for the repository ${fullName}.`,
+    ``,
+    `The source code is the single source of truth. Your goal is to update the`,
+    `MkDocs documentation to accurately reflect the current state of the code.`,
+    `When the documentation conflicts with the source code, the source code is`,
+    `always right. Do not invent features or behaviors — only document what`,
+    `exists in the code.`,
+    ``,
+    `Steps:`,
+    `1. Read \`yeti/OVERVIEW.md\` if it exists, for architecture context.`,
+    `2. Read \`mkdocs.yml\` (or \`mkdocs.yaml\`) to understand the docs structure`,
+    `   and identify the docs directory (default: \`docs/\`).`,
+    `3. Scan recent git history (\`git log --oneline -50\`) to identify source`,
+    `   code changes since the documentation was last updated.`,
+    `4. Read the source code files that changed to understand what actually`,
+    `   changed.`,
+    `5. Update only the Markdown files under the MkDocs docs directory (and`,
+    `   \`mkdocs.yml\` itself if the nav structure needs it). Do NOT modify`,
+    `   source code, \`yeti/\` docs, or binary/media files.`,
+    `6. If no documentation updates are needed (no meaningful source changes),`,
+    `   make no commits.`,
+    `7. Commit changes with message: "docs: update mkdocs content [mkdocs-update]"`,
+    ``,
+    `Do NOT make any source code changes. Only update documentation.`,
+  ].join("\n");
+}
+
+async function processRepo(repo: Repo): Promise<void> {
+  const fullName = repo.fullName;
+
+  // Step 1: Check for existing open mkdocs-update PR
+  const prs = await gh.listPRs(fullName);
+  const hasMkdocsPR = prs.some((pr) => pr.headRefName.startsWith("yeti/mkdocs-update-"));
+  if (hasMkdocsPR) {
+    log.info(`[mkdocs-update] Skipping ${fullName} — open mkdocs-update PR exists`);
+    return;
+  }
+
+  // Step 2: Create worktree and check for mkdocs config
+  const branchName = `yeti/mkdocs-update-${claude.datestamp()}-${claude.randomSuffix()}`;
+  const taskId = db.recordTaskStart("mkdocs-update", fullName, 0, null);
+  let wtPath: string | undefined;
+
+  try {
+    wtPath = await claude.createWorktree(repo, branchName, "mkdocs-update");
+    db.updateTaskWorktree(taskId, wtPath, branchName);
+
+    // Check for mkdocs.yml or mkdocs.yaml
+    const hasMkdocsYml = fs.existsSync(path.join(wtPath, "mkdocs.yml"));
+    const hasMkdocsYaml = fs.existsSync(path.join(wtPath, "mkdocs.yaml"));
+    if (!hasMkdocsYml && !hasMkdocsYaml) {
+      log.info(`[mkdocs-update] Skipping ${fullName} — no mkdocs.yml or mkdocs.yaml`);
+      db.recordTaskComplete(taskId);
+      return;
+    }
+
+    // Step 3: Run AI to update docs
+    log.info(`[mkdocs-update] Updating mkdocs content for ${fullName}`);
+    const prompt = buildMkdocsPrompt(fullName);
+    const aiOptions = JOB_AI["mkdocs-update"];
+    const enqueueFn = aiOptions?.backend === "copilot" ? claude.enqueueCopilot : claude.enqueue;
+    await enqueueFn(() => claude.runAI(prompt, wtPath!, aiOptions));
+
+    // Step 4: Push and create PR
+    if (await claude.hasNewCommits(wtPath, repo.defaultBranch) && await claude.hasTreeDiff(wtPath, repo.defaultBranch)) {
+      const description = await claude.generateDocsPRDescription(wtPath, repo.defaultBranch);
+      await claude.pushBranch(wtPath, branchName);
+      const prNumber = await gh.createPR(
+        fullName,
+        branchName,
+        `docs: update mkdocs content for ${repo.name}`,
+        description,
+      );
+      log.info(`[mkdocs-update] Created PR #${prNumber} for ${fullName}`);
+    } else {
+      log.warn(`[mkdocs-update] No commits produced for ${fullName}`);
+    }
+
+    db.recordTaskComplete(taskId);
+  } catch (err) {
+    db.recordTaskFailed(taskId, String(err));
+    throw err;
+  } finally {
+    if (wtPath) {
+      await claude.removeWorktree(repo, wtPath);
+    }
+  }
+}
+
+export async function run(repos: Repo[]): Promise<void> {
+  const tasks = repos.map((repo) =>
+    processRepo(repo).catch((err) =>
+      reportError("mkdocs-update:process-repo", repo.fullName, err),
+    ),
+  );
+  await Promise.allSettled(tasks);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import * as improvementIdentifier from "./jobs/improvement-identifier.js";
 import * as triageYetiErrors from "./jobs/triage-yeti-errors.js";
 import * as issueAuditor from "./jobs/issue-auditor.js";
 import * as planReviewer from "./jobs/plan-reviewer.js";
+import * as mkdocsUpdate from "./jobs/mkdocs-update.js";
 import * as discord from "./discord.js";
 import { isDiscordConfigured } from "./discord.js";
 import { setShuttingDown } from "./shutdown.js";
@@ -166,6 +167,15 @@ const jobs: Job[] = [
     async run() {
       const repos = await gh.listRepos();
       await improvementIdentifier.run(repos);
+    },
+  },
+  {
+    name: "mkdocs-update",
+    intervalMs: 0,
+    scheduledHour: SCHEDULES.mkdocsUpdateHour,
+    async run() {
+      const repos = await gh.listRepos();
+      await mkdocsUpdate.run(repos);
     },
   },
   {

--- a/src/pages/config.ts
+++ b/src/pages/config.ts
@@ -76,7 +76,7 @@ ${htmlOpenTag(theme)}
     <h2>Jobs &amp; Repos</h2>
     <label for="enabledJobs">Enabled Jobs (comma-separated)</label>
     <input type="text" name="enabledJobs" id="enabledJobs" value="${escapeHtml(Array.isArray(cfg.enabledJobs) ? (cfg.enabledJobs as string[]).join(", ") : "")}">
-    <div class="field-note">Valid jobs: issue-refiner, issue-worker, ci-fixer, review-addresser, doc-maintainer, auto-merger, repo-standards, improvement-identifier, issue-auditor, triage-yeti-errors, plan-reviewer</div>
+    <div class="field-note">Valid jobs: issue-refiner, issue-worker, ci-fixer, review-addresser, doc-maintainer, auto-merger, repo-standards, improvement-identifier, issue-auditor, triage-yeti-errors, plan-reviewer, mkdocs-update</div>
     <div class="field-note">Empty means no jobs will run.</div>
 
     <label for="allowedRepos">Allowed Repos (comma-separated short names)</label>
@@ -129,7 +129,7 @@ ${htmlOpenTag(theme)}
     <table class="config-table">
       <thead><tr><th>Job</th><th>Backend</th><th>Model</th></tr></thead>
       <tbody>
-        ${["issue-refiner", "issue-worker", "ci-fixer", "review-addresser", "doc-maintainer", "improvement-identifier", "plan-reviewer"].map(job => {
+        ${["issue-refiner", "issue-worker", "ci-fixer", "review-addresser", "doc-maintainer", "improvement-identifier", "plan-reviewer", "mkdocs-update"].map(job => {
           const jobCfg = (cfg.jobAi as Record<string, { backend?: string; model?: string }> | undefined)?.[job] ?? {};
           return `<tr>
             <td>${escapeHtml(job)}</td>

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -45,6 +45,7 @@ src/
     ├── auto-merger.ts          Auto-merges Dependabot and approved Yeti PRs
     ├── repo-standards.ts       Syncs labels and cleans legacy labels
     ├── improvement-identifier.ts  Identifies codebase improvements via Claude, implements as PRs
+    ├── mkdocs-update.ts        Daily MkDocs documentation update from recent git changes
     └── issue-auditor.ts        Daily audit ensuring no issues fall between the cracks
 
 deploy/
@@ -266,6 +267,7 @@ See [Jobs](jobs.md) for detailed behavior of each.
 | `auto-merger` | Dependabot PRs + LGTM'd Yeti PRs + doc PRs | 10 min | Squash-merges PRs when conditions are met |
 | `repo-standards` | Daily at 2 AM (+ on startup) | Scheduled | Syncs labels and cleans legacy labels |
 | `improvement-identifier` | Daily at 3 AM | Scheduled | Analyzes codebase via Claude, implements improvements as PRs |
+| `mkdocs-update` | Daily at 4 AM | Scheduled | Updates MkDocs documentation from recent source code changes |
 | `issue-auditor` | Daily at 5 AM | Scheduled | Reconciles issue states, manages Ready and In Review labels |
 
 ## Key Patterns
@@ -425,6 +427,7 @@ repository.
 | triage-yeti-errors | `yeti/investigate-error-<N>-<hex4>` |
 | doc-maintainer | `yeti/docs-<YYYYMMDD>-<hex4>` |
 | improvement-identifier | `yeti/improve-<hex4>` |
+| mkdocs-update | `yeti/mkdocs-update-<YYYYMMDD>-<hex4>` |
 | ci-fixer / review-addresser | Uses existing PR branch |
 
 ### PR Title Conventions
@@ -433,6 +436,7 @@ repository.
 - `fix(#N): <phase title> (X/Y)` — multi-PR issue phases
 - `refactor: <title>` — automated improvements
 - `docs: update documentation for <repo>` — doc maintenance
+- `docs: update mkdocs content for <repo>` — mkdocs updates
 
 ### Tree-Diff Guard
 
@@ -450,6 +454,7 @@ prevent pile-up when previous PRs haven't been merged:
 
 - **doc-maintainer**: Skips if an open `yeti/docs-*` PR exists
 - **improvement-identifier**: Skips if any open `yeti/improve-*` PR exists
+- **mkdocs-update**: Skips if an open `yeti/mkdocs-update-*` PR exists
 - **ci-fixer**: Uses consolidated per-repo `[ci-unrelated]` issues rather
   than per-fingerprint issues, so all unrelated CI failures for a repo
   are tracked in a single issue
@@ -524,7 +529,7 @@ Controls which jobs are registered with the scheduler at startup.
 - **Field**: `enabledJobs` (string array)
 - **Default**: `[]` — no jobs run if the field is absent or empty
 - **Live-reloadable**: yes (changes take effect without restart)
-- **Available values**: `issue-worker`, `issue-refiner`, `plan-reviewer`, `ci-fixer`, `review-addresser`, `doc-maintainer`, `auto-merger`, `repo-standards`, `improvement-identifier`, `issue-auditor`, `triage-yeti-errors`
+- **Available values**: `issue-worker`, `issue-refiner`, `plan-reviewer`, `ci-fixer`, `review-addresser`, `doc-maintainer`, `auto-merger`, `repo-standards`, `improvement-identifier`, `issue-auditor`, `triage-yeti-errors`, `mkdocs-update`
 
 **Migration note**: existing configs without `enabledJobs` will have no jobs start after upgrading. Add the desired job names to `enabledJobs` in `~/.yeti/config.json` before upgrading.
 


### PR DESCRIPTION
## Summary

Adds a new `mkdocs-update` job that automatically updates MkDocs documentation based on recent source code changes. The job runs daily at 4 AM, skips repositories without a `mkdocs.yml`/`mkdocs.yaml` config file, and follows the improvement-identifier pattern: scan, update via AI, create a PR. The AI prompt emphasizes that source code is the single source of truth — when docs conflict with code, the code wins.

Closes #64

## Changes

- New `src/jobs/mkdocs-update.ts` job with mkdocs.yml/yaml detection, AI-driven doc updates, tree-diff guard, and duplicate-PR skipping
- Comprehensive test suite in `src/jobs/mkdocs-update.test.ts` covering skip conditions, PR creation, error handling, worktree cleanup, and copilot backend support
- Registered the job in `src/main.ts` as a scheduled daily job using `SCHEDULES.mkdocsUpdateHour`
- Added `mkdocsUpdateHour` config field (default: 4 AM) to `src/config.ts` and `deploy/install.sh`
- Updated dashboard config page (`src/pages/config.ts`) to include mkdocs-update in valid jobs list and AI backend table
- Updated `yeti/OVERVIEW.md` with job documentation, branch naming, PR title conventions, and duplicate-PR guard info

Closes #64