### PR TITLE
docs: update documentation for yeti

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -61,7 +61,7 @@ deploy/
 
 **`main.ts`** — Wires everything together. Initializes the SQLite database,
 recovers orphaned tasks from a previous crash (cleans up dangling worktrees,
-marks tasks failed), prunes old logs, registers all 11 jobs with the scheduler
+marks tasks failed), prunes old logs, registers all 12 jobs with the scheduler
 (interval jobs staggered by 2 seconds to prevent thundering herd), starts the
 HTTP server, launches the **queue label scanner** (an infrastructure timer that
 runs `scanQueueLabels()` on a configurable interval to keep the dashboard queue
@@ -252,7 +252,7 @@ The web dashboard is a first-class consumer of job, config, and queue data. Page
 
 ## Jobs
 
-Eleven scheduled jobs run on timers or schedules.
+Twelve scheduled jobs run on timers or schedules.
 See [Jobs](jobs.md) for detailed behavior of each.
 
 | Job | Trigger | Interval | Summary |
@@ -503,6 +503,7 @@ defaults.
 | `schedules.docMaintainerHour` | — | `1` (1 AM local time) |
 | `schedules.repoStandardsHour` | — | `2` (2 AM local time) |
 | `schedules.improvementIdentifierHour` | — | `3` (3 AM local time) |
+| `schedules.mkdocsUpdateHour` | — | `4` (4 AM local time) |
 | `schedules.issueAuditorHour` | — | `5` (5 AM local time) |
 | `logRetentionDays` | — | `14` |
 | `logRetentionPerJob` | — | `20` |

--- a/yeti/jobs.md
+++ b/yeti/jobs.md
@@ -412,6 +412,31 @@ documentation suggestions. "No improvements found" is acceptable.
 
 PRs created include a footer: *"Automated improvement by yeti improvement-identifier"*
 
+## mkdocs-update
+
+**Source**: `src/jobs/mkdocs-update.ts`
+**Trigger**: Daily schedule
+**Schedule**: Runs at hour configured by `schedules.mkdocsUpdateHour`
+(default: 4 AM local time)
+
+Scans repos for `mkdocs.yml` or `mkdocs.yaml` files and updates MkDocs
+documentation to reflect recent source code changes. Follows the same
+structure as doc-maintainer (single-phase, one PR per repo).
+
+- Skips if an open `yeti/mkdocs-update-*` PR already exists for the repo
+- Creates a worktree on branch `yeti/mkdocs-update-<YYYYMMDD>-<hex4>`
+- Checks for `mkdocs.yml` or `mkdocs.yaml` in the worktree root; skips
+  repos without either file (recorded as completed, not failed)
+- Instructs Claude to read the MkDocs config, scan recent git history,
+  and update only Markdown files under the docs directory (and
+  `mkdocs.yml` itself if the nav structure needs it)
+- Uses `JOB_AI` backend dispatch (supports both Claude and Copilot
+  backends via `JOB_AI["mkdocs-update"]`)
+- If commits were produced with a tree diff: pushes and creates a PR
+  titled `docs: update mkdocs content for <repo>`
+- Repos are processed concurrently with `Promise.allSettled`; errors in
+  one repo do not block others
+
 ## issue-auditor
 
 **Source**: `src/jobs/issue-auditor.ts`


### PR DESCRIPTION
## Summary

Updates AI-facing documentation to reflect the addition of the new `mkdocs-update` job introduced in #66. The job count, configuration table, and job reference docs are updated to stay consistent with the current codebase.

## Changes

- Updated job count from 11 to 12 in `yeti/OVERVIEW.md` (main.ts description and jobs summary)
- Added `schedules.mkdocsUpdateHour` to the configuration reference table in `yeti/OVERVIEW.md`
- Added full `mkdocs-update` job documentation section in `yeti/jobs.md` covering trigger, schedule, behavior, and error handling