### PR TITLE
docs: update mkdocs content for yeti

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
           - issue-auditor: reference/jobs/issue-auditor.md
           - repo-standards: reference/jobs/repo-standards.md
           - triage-yeti-errors: reference/jobs/triage-yeti-errors.md
+          - mkdocs-update: reference/jobs/mkdocs-update.md
 
 extra_css:
   - stylesheets/extra.css

--- a/site/reference/configuration.md
+++ b/site/reference/configuration.md
@@ -73,6 +73,7 @@ All schedule fields live inside the `schedules` object, are specified as hour of
 | `docMaintainerHour` | `1` (1 AM) | doc-maintainer run hour |
 | `repoStandardsHour` | `2` (2 AM) | repo-standards run hour |
 | `improvementIdentifierHour` | `3` (3 AM) | improvement-identifier run hour |
+| `mkdocsUpdateHour` | `4` (4 AM) | mkdocs-update run hour |
 | `issueAuditorHour` | `5` (5 AM) | issue-auditor run hour |
 
 ---
@@ -139,7 +140,8 @@ A more complete configuration with intervals, schedules, and integrations:
     "doc-maintainer",
     "repo-standards",
     "improvement-identifier",
-    "issue-auditor"
+    "issue-auditor",
+    "mkdocs-update"
   ],
   "intervals": {
     "issueWorkerMs": 300000,
@@ -150,6 +152,7 @@ A more complete configuration with intervals, schedules, and integrations:
     "docMaintainerHour": 1,
     "repoStandardsHour": 2,
     "improvementIdentifierHour": 3,
+    "mkdocsUpdateHour": 4,
     "issueAuditorHour": 5
   },
   "jobAi": {

--- a/site/reference/jobs/index.md
+++ b/site/reference/jobs/index.md
@@ -27,6 +27,7 @@ These jobs run once daily at a configured hour (local timezone). They also run o
 | [doc-maintainer](doc-maintainer.md) | 1 AM | Yes | Update repository documentation |
 | [repo-standards](repo-standards.md) | 2 AM | No | Sync labels to all repositories |
 | [improvement-identifier](improvement-identifier.md) | 3 AM | Yes | Find codebase improvements and implement them as PRs |
+| [mkdocs-update](mkdocs-update.md) | 4 AM | Yes | Update MkDocs documentation sites |
 | [issue-auditor](issue-auditor.md) | 5 AM | No | Audit and fix issue label state |
 
 ---
@@ -59,7 +60,7 @@ Add more jobs as you grow comfortable with the workflow:
 - **`repo-standards`** -- Keeps labels in sync
 - **`review-addresser`** -- Handles PR review comments
 
-The full set including nightly jobs (`doc-maintainer`, `improvement-identifier`, `issue-auditor`) rounds out a fully autonomous setup.
+The full set including nightly jobs (`doc-maintainer`, `improvement-identifier`, `issue-auditor`, `mkdocs-update`) rounds out a fully autonomous setup.
 
 ---
 

--- a/site/reference/jobs/mkdocs-update.md
+++ b/site/reference/jobs/mkdocs-update.md
@@ -1,0 +1,58 @@
+# mkdocs-update
+
+> Updates MkDocs documentation sites to reflect the current state of the codebase.
+
+| Property | Value |
+|----------|-------|
+| Type | Scheduled |
+| Default hour | 4 AM (`schedules.mkdocsUpdateHour`) |
+| Uses AI | Yes |
+| Backend | Claude (configurable via `jobAi`) |
+| Config key | `schedules.mkdocsUpdateHour` |
+
+## What it does
+
+The mkdocs-update job runs daily to keep MkDocs-based documentation sites in sync with source code changes. It uses AI to read recent git history, understand what changed, and update the Markdown files under the MkDocs docs directory accordingly.
+
+## Trigger
+
+Scheduled to run once daily. Also runs on startup if the scheduled hour has passed since the last run.
+
+Skips processing when:
+
+- An open PR with a `yeti/mkdocs-update-*` branch already exists for the repo
+- The repo does not have a `mkdocs.yml` or `mkdocs.yaml` file
+
+## Labels
+
+This job does not interact with labels.
+
+## How it works
+
+1. **Check for existing PR** -- Skips if any open PR has a `yeti/mkdocs-update-*` branch
+2. **Create worktree** on branch `yeti/mkdocs-update-<datestamp>-<hex4>`
+3. **Check for MkDocs config** -- Skips repos without `mkdocs.yml` or `mkdocs.yaml`
+4. **Run AI** -- Instructs the AI to:
+    - Read `yeti/OVERVIEW.md` for architecture context
+    - Read the MkDocs config to understand the docs structure
+    - Scan recent git history for source code changes
+    - Read changed source files to understand what actually changed
+    - Update only Markdown files under the docs directory (and `mkdocs.yml` if nav changes are needed)
+    - Commit with message `docs: update mkdocs content [mkdocs-update]`
+5. **Push and create PR** -- Only if there are actual tree differences. PR titled `docs: update mkdocs content for <repo>`
+
+### Source of Truth
+
+The AI is instructed that source code is the single source of truth. When documentation conflicts with the code, the code is always right. The AI does not invent features or behaviors -- it only documents what exists.
+
+### Auto-merge Path
+
+MkDocs update PRs created by this job are automatically merged by the [auto-merger](auto-merger.md) when:
+
+- All changed files are under the docs directory or end in `.md`
+- CI checks pass or no checks are configured
+
+## Related jobs
+
+- [doc-maintainer](doc-maintainer.md) -- Updates `yeti/` AI-facing documentation (separate from MkDocs user-facing docs)
+- [auto-merger](auto-merger.md) -- Merges the docs PRs this job creates


### PR DESCRIPTION
## Summary

Add documentation for the new `mkdocs-update` job, which keeps MkDocs-based documentation sites in sync with source code changes by running AI-driven updates on a daily schedule. Updates existing reference pages to include the new job in navigation, job listings, configuration tables, and example configs.

## Changes

- Add new reference page `site/reference/jobs/mkdocs-update.md` covering trigger conditions, workflow steps, auto-merge behavior, and related jobs
- Add `mkdocsUpdateHour` schedule field to the configuration reference with default of 4 AM
- Add `mkdocs-update` to the jobs index table and recommended full-setup list
- Update example config to include `mkdocs-update` in `enabledJobs` and `schedules`
- Add nav entry in `mkdocs.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)