### PR TITLE
Add MkDocs GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install mkdocs-material
+      - run: mkdocs build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and deploy MkDocs Material site to GitHub Pages
- Triggers on pushes to main affecting `site/`, `mkdocs.yml`, or the workflow itself
- Supports manual dispatch via `workflow_dispatch`

## Setup
Enable GitHub Pages with "GitHub Actions" source in repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)