### PR TITLE
fix: resolve #73 — Migrate MkDocs to MaterialX

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-materialx
       - run: mkdocs build
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,13 @@
 site_name: Yeti
 site_description: Self-hosted GitHub automation that plans, implements, and maintains your repos — so you can stay in the cold zone.
-site_url: ""
+site_url: https://frostyard.github.io/yeti/
+repo_url: https://github.com/frostyard/yeti
+repo_name: frostyard/yeti
 docs_dir: site
 site_dir: _site
 
 theme:
-  name: material
+  name: materialx
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
## Summary

Migrates the MkDocs documentation site from `mkdocs-material` to `mkdocs-materialx`, resolving #73. Also adds the GitHub repository link to the site's top navigation bar via `repo_url` and `repo_name` config, and sets the correct `site_url`.

## Changes

- Switched pip install from `mkdocs-material` to `mkdocs-materialx` in the GitHub Actions docs workflow
- Changed MkDocs theme from `material` to `materialx`
- Added `repo_url` and `repo_name` to `mkdocs.yml` for GitHub nav link
- Set `site_url` to the correct GitHub Pages URL

Closes #73