### PR TITLE
fix: resolve #75 — Web dashboard title should display github org after "Yeti"

### DIFF
--- a/src/pages/config.ts
+++ b/src/pages/config.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "./layout.js";
-import { PAGE_CSS, escapeHtml, htmlOpenTag, buildNav, THEME_SCRIPT } from "./layout.js";
+import { PAGE_CSS, escapeHtml, htmlOpenTag, buildNav, THEME_SCRIPT, siteTitle } from "./layout.js";
 import { getConfigForDisplay } from "../config.js";
 import * as config from "../config.js";
 
@@ -44,7 +44,7 @@ ${htmlOpenTag(theme)}
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>yeti — config</title>
+  <title>${siteTitle("config")}</title>
   <style>${PAGE_CSS}</style>
 </head>
 <body>

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "./layout.js";
-import { PAGE_CSS, escapeHtml, repoShortName, itemLogsUrl, formatUptime, formatRelativeTime, formatCountdown, htmlOpenTag, buildNav, THEME_SCRIPT, discordLabel } from "./layout.js";
+import { PAGE_CSS, escapeHtml, repoShortName, itemLogsUrl, formatUptime, formatRelativeTime, formatCountdown, htmlOpenTag, buildNav, THEME_SCRIPT, discordLabel, siteTitle } from "./layout.js";
 import { msUntilHour } from "../scheduler.js";
 
 interface RunningTaskInfo {
@@ -107,7 +107,7 @@ ${htmlOpenTag(theme)}
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>yeti</title>
+  <title>${siteTitle()}</title>
   <style>${PAGE_CSS}</style>
 </head>
 <body>

--- a/src/pages/layout.test.ts
+++ b/src/pages/layout.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../config.js", () => ({
+  GITHUB_OWNERS: ["frostyard"],
+}));
+
+import { siteTitle } from "./layout.js";
+import * as config from "../config.js";
+
+describe("siteTitle", () => {
+  beforeEach(() => {
+    (config as { GITHUB_OWNERS: string[] }).GITHUB_OWNERS = ["frostyard"];
+  });
+
+  it("includes org name", () => {
+    expect(siteTitle()).toBe("yeti — frostyard");
+  });
+
+  it("appends suffix after org", () => {
+    expect(siteTitle("Queue")).toBe("yeti — frostyard — Queue");
+  });
+
+  it("returns plain yeti when no orgs configured", () => {
+    (config as { GITHUB_OWNERS: string[] }).GITHUB_OWNERS = [];
+    expect(siteTitle()).toBe("yeti");
+  });
+
+  it("joins multiple orgs with comma", () => {
+    (config as { GITHUB_OWNERS: string[] }).GITHUB_OWNERS = ["a", "b"];
+    expect(siteTitle()).toBe("yeti — a, b");
+  });
+
+  it("escapes HTML in org names", () => {
+    (config as { GITHUB_OWNERS: string[] }).GITHUB_OWNERS = ["<script>"];
+    expect(siteTitle()).toBe("yeti — &lt;script&gt;");
+  });
+});

--- a/src/pages/layout.ts
+++ b/src/pages/layout.ts
@@ -1,3 +1,5 @@
+import { GITHUB_OWNERS } from "../config.js";
+
 export type Theme = "dark" | "light" | "system";
 
 const LIGHT_THEME_VARS = `
@@ -387,6 +389,12 @@ export const PAGE_CSS = `
 
 export function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+export function siteTitle(suffix?: string): string {
+  const org = GITHUB_OWNERS.map(o => escapeHtml(o)).join(", ");
+  const base = org ? `yeti — ${org}` : "yeti";
+  return suffix ? `${base} — ${suffix}` : base;
 }
 
 export function repoShortName(fullName: string): string {

--- a/src/pages/login.ts
+++ b/src/pages/login.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "./layout.js";
-import { PAGE_CSS, htmlOpenTag, THEME_SCRIPT } from "./layout.js";
+import { PAGE_CSS, htmlOpenTag, THEME_SCRIPT, siteTitle } from "./layout.js";
 
 export function buildLoginPage(error: boolean, theme: Theme): string {
   return `<!DOCTYPE html>
@@ -7,7 +7,7 @@ ${htmlOpenTag(theme)}
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>yeti — login</title>
+  <title>${siteTitle("login")}</title>
   <style>${PAGE_CSS}</style>
 </head>
 <body>

--- a/src/pages/logs.ts
+++ b/src/pages/logs.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "./layout.js";
-import { PAGE_CSS, escapeHtml, formatDuration, htmlOpenTag, buildNav, THEME_SCRIPT } from "./layout.js";
+import { PAGE_CSS, escapeHtml, formatDuration, htmlOpenTag, buildNav, THEME_SCRIPT, siteTitle } from "./layout.js";
 import type { JobRun, JobLog, Task } from "../db.js";
 
 function logLevelClass(level: string): string {
@@ -42,7 +42,7 @@ ${htmlOpenTag(theme)}
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>yeti — logs</title>
+  <title>${siteTitle("logs")}</title>
   <style>${PAGE_CSS}</style>
 </head>
 <body>
@@ -147,7 +147,7 @@ ${htmlOpenTag(theme)}
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>yeti — ${escapeHtml(shortRepo)}#${itemNumber} logs</title>
+  <title>${siteTitle(`${escapeHtml(shortRepo)}#${itemNumber} logs`)}</title>
   <style>${PAGE_CSS}</style>
 </head>
 <body>
@@ -217,7 +217,7 @@ ${htmlOpenTag(theme)}
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>yeti — ${escapeHtml(run.job_name)} run</title>
+  <title>${siteTitle(`${escapeHtml(run.job_name)} run`)}</title>
   <style>${PAGE_CSS}</style>
 </head>
 <body>

--- a/src/pages/queue.ts
+++ b/src/pages/queue.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "./layout.js";
-import { PAGE_CSS, escapeHtml, repoShortName, itemLogsUrl, formatRelativeTime, htmlOpenTag, buildNav, THEME_SCRIPT } from "./layout.js";
+import { PAGE_CSS, escapeHtml, repoShortName, itemLogsUrl, formatRelativeTime, htmlOpenTag, buildNav, THEME_SCRIPT, siteTitle } from "./layout.js";
 import type { QueueItem, QueueCategory } from "../github.js";
 
 const CATEGORY_DISPLAY: Record<QueueCategory, { label: string; color: string }> = {
@@ -137,7 +137,7 @@ ${htmlOpenTag(theme)}
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="refresh" content="60">
-  <title>yeti — Queue</title>
+  <title>${siteTitle("Queue")}</title>
   <style>${PAGE_CSS}
   .priority-star { color: #f0ad4e; margin-right: 4px; font-size: 1.1em; }
   .prio-btn, .skip-btn, .restore-btn { padding: 2px 8px; margin-left: 4px; border: 1px solid var(--border); border-radius: 4px; cursor: pointer; font-size: 0.85em; background: var(--bg-secondary); color: var(--text); }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -4,6 +4,7 @@ import http from "node:http";
 vi.mock("./config.js", () => ({
   SERVER_PORT: 0,
   AUTH_TOKEN: "",
+  GITHUB_OWNERS: ["owner1"],
   LABELS: {
     refined: "Refined",
     ready: "Ready",


### PR DESCRIPTION
## Summary

Displays the configured GitHub org(s) in the web dashboard title so it's clear which Yeti instance you're looking at. All page titles now follow the pattern `yeti — {org} — {page}` instead of the previous `yeti — {page}`.

## Changes

- Added `siteTitle()` helper in `src/pages/layout.ts` that builds the title from `GITHUB_OWNERS` config, with optional page suffix
- Updated all page builders (dashboard, config, queue, logs, login) to use `siteTitle()` instead of hardcoded titles
- Added tests for `siteTitle()` covering single org, multiple orgs, no orgs, and HTML escaping

Closes #75