### PR TITLE
fix: resolve #78 — discord notifications should include a link to the appropriate page on GITHUB

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -91,6 +91,8 @@ import {
   getPRReviewDecision,
   scanQueueLabels,
   clearQueueCacheByCategories,
+  issueUrl,
+  pullUrl,
 } from "./github.js";
 
 describe("gh retry logic", () => {
@@ -2076,5 +2078,15 @@ describe("scanQueueLabels", () => {
     // Restore defaults
     (config as Record<string, unknown>).SKIPPED_ITEMS = [];
     (config as Record<string, unknown>).PRIORITIZED_ITEMS = [];
+  });
+});
+
+describe("URL helpers", () => {
+  it("issueUrl builds correct GitHub issue URL", () => {
+    expect(issueUrl("frostyard/yeti", 78)).toBe("https://github.com/frostyard/yeti/issues/78");
+  });
+
+  it("pullUrl builds correct GitHub pull request URL", () => {
+    expect(pullUrl("frostyard/yeti", 42)).toBe("https://github.com/frostyard/yeti/pull/42");
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -105,6 +105,14 @@ export function stripYetiMarker(body: string): string {
   return body.replace(YETI_COMMENT_MARKER, "").replace(YETI_VISIBLE_HEADER, "").trim();
 }
 
+export function issueUrl(fullName: string, number: number): string {
+  return `https://github.com/${fullName}/issues/${number}`;
+}
+
+export function pullUrl(fullName: string, number: number): string {
+  return `https://github.com/${fullName}/pull/${number}`;
+}
+
 // ── Repo cache (shared across all jobs) ──
 
 const REPO_CACHE_TTL = 5 * 60 * 1000; // 5 minutes

--- a/src/jobs/auto-merger.test.ts
+++ b/src/jobs/auto-merger.test.ts
@@ -37,6 +37,8 @@ const { mockGh } = vi.hoisted(() => ({
     isItemSkipped: vi.fn().mockReturnValue(false),
     hasPriorityLabel: vi.fn().mockReturnValue(false),
     populateQueueCache: vi.fn(),
+    issueUrl: (fullName: string, number: number) => `https://github.com/${fullName}/issues/${number}`,
+    pullUrl: (fullName: string, number: number) => `https://github.com/${fullName}/pull/${number}`,
   },
 }));
 

--- a/src/jobs/auto-merger.ts
+++ b/src/jobs/auto-merger.ts
@@ -60,7 +60,7 @@ export async function run(repos: Repo[]): Promise<void> {
           gh.populateQueueCache("auto-mergeable", repo.fullName, { number: pr.number, title: pr.title, type: "pr", updatedAt: pr.updatedAt, priority: gh.hasPriorityLabel(pr.labels) });
           log.info(`[auto-merger] Merging ${repo.fullName}#${pr.number}: ${pr.title}`);
           await gh.mergePR(repo.fullName, pr.number);
-          notify(`[auto-merger] Merged ${repo.fullName}#${pr.number}`);
+          notify(`[auto-merger] Merged ${repo.fullName}#${pr.number}\n${gh.pullUrl(repo.fullName, pr.number)}`);
 
           if (isYetiPR) {
             const match = pr.headRefName.match(/^yeti\/issue-(\d+)-/);

--- a/src/jobs/ci-fixer.test.ts
+++ b/src/jobs/ci-fixer.test.ts
@@ -53,6 +53,8 @@ const { mockGh, mockClaude, mockDb, MockRateLimitError } = vi.hoisted(() => {
     editIssueComment: vi.fn(),
     isYetiComment: vi.fn(),
     RateLimitError: MockRateLimitError,
+    issueUrl: (fullName: string, number: number) => `https://github.com/${fullName}/issues/${number}`,
+    pullUrl: (fullName: string, number: number) => `https://github.com/${fullName}/pull/${number}`,
   },
   mockClaude: {
     createWorktreeFromBranch: vi.fn(),

--- a/src/jobs/ci-fixer.ts
+++ b/src/jobs/ci-fixer.ts
@@ -35,7 +35,7 @@ async function resolveConflicts(repo: Repo, pr: gh.PR): Promise<boolean> {
       // Merge was auto-resolved by git — just push
       await claude.pushBranch(wtPath, pr.headRefName);
       log.info(`[ci-fixer] Clean merge pushed for ${fullName}#${pr.number}`);
-      notify(`[ci-fixer] Resolved merge conflict for ${fullName}#${pr.number}`);
+      notify(`[ci-fixer] Resolved merge conflict for ${fullName}#${pr.number}\n${gh.pullUrl(fullName, pr.number)}`);
       db.recordTaskComplete(taskId);
       return true;
     }
@@ -72,7 +72,7 @@ async function resolveConflicts(repo: Repo, pr: gh.PR): Promise<boolean> {
         log.warn(`[ci-fixer] Failed to update PR description for ${fullName}#${pr.number}: ${descErr}`);
       }
       log.info(`[ci-fixer] Conflict resolution pushed for ${fullName}#${pr.number}`);
-      notify(`[ci-fixer] Resolved merge conflict for ${fullName}#${pr.number}`);
+      notify(`[ci-fixer] Resolved merge conflict for ${fullName}#${pr.number}\n${gh.pullUrl(fullName, pr.number)}`);
     } else {
       log.warn(`[ci-fixer] No commits from conflict resolution for ${fullName}#${pr.number}`);
       await claude.abortMerge(wtPath);
@@ -267,7 +267,7 @@ async function fixCI(repo: Repo, pr: gh.PR, failLog: string): Promise<void> {
         log.warn(`[ci-fixer] Failed to update PR description for ${fullName}#${pr.number}: ${descErr}`);
       }
       log.info(`[ci-fixer] Pushed fix for ${fullName}#${pr.number}`);
-      notify(`[ci-fixer] Pushed fix for ${fullName}#${pr.number}`);
+      notify(`[ci-fixer] Pushed fix for ${fullName}#${pr.number}\n${gh.pullUrl(fullName, pr.number)}`);
     } else {
       log.warn(`[ci-fixer] No commits produced for ${fullName}#${pr.number}`);
     }
@@ -303,7 +303,7 @@ async function fileUnrelatedIssue(
       ].join("\n");
       issueNumber = await gh.createIssue(repoName, title, body, []);
       log.info(`[ci-fixer] Created issue #${issueNumber} for unrelated CI failures`);
-      notify(`[ci-fixer] Created ci-unrelated issue ${repoName}#${issueNumber}`);
+      notify(`[ci-fixer] Created ci-unrelated issue ${repoName}#${issueNumber}\n${gh.issueUrl(repoName, issueNumber)}`);
     }
 
     for (const occ of occurrences) {

--- a/src/jobs/doc-maintainer.test.ts
+++ b/src/jobs/doc-maintainer.test.ts
@@ -32,6 +32,7 @@ const { mockFs, mockGh, mockClaude, mockDb, mockPlanParser } = vi.hoisted(() => 
     createPR: vi.fn(),
     listRecentlyClosedIssues: vi.fn(),
     getIssueComments: vi.fn(),
+    pullUrl: (fullName: string, number: number) => `https://github.com/${fullName}/pull/${number}`,
   },
   mockClaude: {
     createWorktree: vi.fn(),

--- a/src/jobs/doc-maintainer.ts
+++ b/src/jobs/doc-maintainer.ts
@@ -149,7 +149,7 @@ async function processRepo(repo: Repo): Promise<void> {
         description,
       );
       log.info(`[doc-maintainer] Created docs PR #${prNumber} for ${fullName}`);
-      notify(`[doc-maintainer] Created PR #${prNumber} for ${fullName}`);
+      notify(`[doc-maintainer] Created PR #${prNumber} for ${fullName}\n${gh.pullUrl(fullName, prNumber)}`);
     } else {
       log.warn(`[doc-maintainer] No commits produced for ${fullName}`);
     }

--- a/src/jobs/improvement-identifier.test.ts
+++ b/src/jobs/improvement-identifier.test.ts
@@ -30,6 +30,7 @@ const { mockFs, mockGh, mockClaude, mockDb } = vi.hoisted(() => ({
     searchIssues: vi.fn(),
     searchPRs: vi.fn(),
     createPR: vi.fn(),
+    pullUrl: (fullName: string, number: number) => `https://github.com/${fullName}/pull/${number}`,
   },
   mockClaude: {
     createWorktree: vi.fn(),

--- a/src/jobs/improvement-identifier.ts
+++ b/src/jobs/improvement-identifier.ts
@@ -198,7 +198,7 @@ async function processRepo(repo: Repo): Promise<void> {
         const prBody = improvement.body + FOOTER;
         const prNumber = await gh.createPR(fullName, implBranch, `refactor: ${improvement.title}`, prBody);
         log.info(`[improvement-identifier] Created PR for "${improvement.title}" in ${fullName}`);
-        notify(`[improvement-identifier] Created PR #${prNumber} for ${fullName}`);
+        notify(`[improvement-identifier] Created PR #${prNumber} for ${fullName}\n${gh.pullUrl(fullName, prNumber)}`);
       } else {
         log.warn(`[improvement-identifier] No commits produced for "${improvement.title}" in ${fullName}`);
       }

--- a/src/jobs/issue-refiner.test.ts
+++ b/src/jobs/issue-refiner.test.ts
@@ -45,6 +45,7 @@ const { mockGh, mockClaude, mockDb } = vi.hoisted(() => ({
     isItemSkipped: vi.fn().mockReturnValue(false),
     hasPriorityLabel: vi.fn().mockReturnValue(false),
     populateQueueCache: vi.fn(),
+    issueUrl: (fullName: string, number: number) => `https://github.com/${fullName}/issues/${number}`,
   },
   mockClaude: {
     createWorktree: vi.fn(),

--- a/src/jobs/issue-refiner.ts
+++ b/src/jobs/issue-refiner.ts
@@ -168,7 +168,7 @@ async function processIssue(repo: Repo, issue: gh.Issue): Promise<void> {
     if (planOutput.trim()) {
       await gh.commentOnIssue(fullName, issue.number, `${PLAN_HEADER}\n\n${planOutput}`);
       log.info(`[issue-refiner] Posted plan for ${fullName}#${issue.number}`);
-      notify(`[issue-refiner] Plan produced for ${fullName}#${issue.number}`);
+      notify(`[issue-refiner] Plan produced for ${fullName}#${issue.number}\n${gh.issueUrl(fullName, issue.number)}`);
     } else {
       log.warn(`[issue-refiner] Empty plan output for ${fullName}#${issue.number}`);
     }
@@ -224,7 +224,7 @@ async function processRefinement(
       if (planOutput.trim()) {
         await gh.commentOnIssue(fullName, issue.number, `${PLAN_HEADER}\n\n${planOutput}`);
         log.info(`[issue-refiner] Posted fresh plan for ${fullName}#${issue.number}`);
-        notify(`[issue-refiner] Plan produced for ${fullName}#${issue.number}`);
+        notify(`[issue-refiner] Plan produced for ${fullName}#${issue.number}\n${gh.issueUrl(fullName, issue.number)}`);
       } else {
         log.warn(`[issue-refiner] Empty plan output for ${fullName}#${issue.number}`);
       }
@@ -245,7 +245,7 @@ async function processRefinement(
 
         await gh.editIssueComment(fullName, planComment.id, `${PLAN_HEADER}\n\n${planBody}`);
         log.info(`[issue-refiner] Updated plan comment for ${fullName}#${issue.number}`);
-        notify(`[issue-refiner] Plan updated for ${fullName}#${issue.number}`);
+        notify(`[issue-refiner] Plan updated for ${fullName}#${issue.number}\n${gh.issueUrl(fullName, issue.number)}`);
 
         if (noteMatch) {
           await gh.commentOnIssue(fullName, issue.number, `### Note\n${noteMatch[1].trim()}`);

--- a/src/jobs/issue-worker.test.ts
+++ b/src/jobs/issue-worker.test.ts
@@ -44,6 +44,7 @@ const { mockGh, mockClaude, mockDb } = vi.hoisted(() => ({
     isItemPrioritized: vi.fn().mockReturnValue(false),
     hasPriorityLabel: vi.fn().mockReturnValue(false),
     populateQueueCache: vi.fn(),
+    pullUrl: (fullName: string, number: number) => `https://github.com/${fullName}/pull/${number}`,
   },
   mockClaude: {
     createWorktree: vi.fn(),

--- a/src/jobs/issue-worker.ts
+++ b/src/jobs/issue-worker.ts
@@ -206,7 +206,7 @@ async function processIssue(repo: Repo, issue: gh.Issue): Promise<void> {
 
       const prNumber = await gh.createPR(fullName, branchName, prTitle, prBody);
       log.info(`[issue-worker] Created PR #${prNumber} (${currentPhase}/${totalPhases}) for ${fullName}#${issue.number}`);
-      notify(`[issue-worker] Created PR #${prNumber} for ${fullName}#${issue.number}`);
+      notify(`[issue-worker] Created PR #${prNumber} for ${fullName}#${issue.number}\n${gh.pullUrl(fullName, prNumber)}`);
       await gh.addLabel(fullName, issue.number, LABELS.inReview);
 
       // Propagate Priority label to the new PR

--- a/src/jobs/mkdocs-update.test.ts
+++ b/src/jobs/mkdocs-update.test.ts
@@ -28,6 +28,7 @@ const { mockFs, mockGh, mockClaude, mockDb } = vi.hoisted(() => ({
   mockGh: {
     listPRs: vi.fn(),
     createPR: vi.fn(),
+    pullUrl: (fullName: string, number: number) => `https://github.com/${fullName}/pull/${number}`,
   },
   mockClaude: {
     createWorktree: vi.fn(),

--- a/src/jobs/mkdocs-update.ts
+++ b/src/jobs/mkdocs-update.ts
@@ -84,7 +84,7 @@ async function processRepo(repo: Repo): Promise<void> {
         description,
       );
       log.info(`[mkdocs-update] Created PR #${prNumber} for ${fullName}`);
-      notify(`[mkdocs-update] Created PR #${prNumber} for ${fullName}`);
+      notify(`[mkdocs-update] Created PR #${prNumber} for ${fullName}\n${gh.pullUrl(fullName, prNumber)}`);
     } else {
       log.warn(`[mkdocs-update] No commits produced for ${fullName}`);
     }

--- a/src/jobs/plan-reviewer.test.ts
+++ b/src/jobs/plan-reviewer.test.ts
@@ -43,6 +43,7 @@ const { mockGh, mockClaude, mockDb } = vi.hoisted(() => ({
     isItemSkipped: vi.fn().mockReturnValue(false),
     hasPriorityLabel: vi.fn().mockReturnValue(false),
     populateQueueCache: vi.fn(),
+    issueUrl: (fullName: string, number: number) => `https://github.com/${fullName}/issues/${number}`,
   },
   mockClaude: {
     createWorktree: vi.fn(),

--- a/src/jobs/plan-reviewer.ts
+++ b/src/jobs/plan-reviewer.ts
@@ -67,7 +67,7 @@ async function processIssue(repo: Repo, issue: gh.Issue, planComment: gh.IssueCo
 
     await gh.commentOnIssue(fullName, issue.number, `${REVIEW_HEADER}\n\n${reviewOutput}`);
     log.info(`[plan-reviewer] Posted review for ${fullName}#${issue.number}`);
-    notify(`[plan-reviewer] Review posted for ${fullName}#${issue.number}`);
+    notify(`[plan-reviewer] Review posted for ${fullName}#${issue.number}\n${gh.issueUrl(fullName, issue.number)}`);
 
     // Mark plan comment as processed
     await gh.addReaction(fullName, planComment.id, "+1");

--- a/src/jobs/review-addresser.test.ts
+++ b/src/jobs/review-addresser.test.ts
@@ -38,6 +38,7 @@ const { mockGh, mockClaude, mockDb } = vi.hoisted(() => ({
     isItemSkipped: vi.fn().mockReturnValue(false),
     hasPriorityLabel: vi.fn().mockReturnValue(false),
     populateQueueCache: vi.fn(),
+    pullUrl: (fullName: string, number: number) => `https://github.com/${fullName}/pull/${number}`,
   },
   mockClaude: {
     createWorktreeFromBranch: vi.fn(),

--- a/src/jobs/review-addresser.ts
+++ b/src/jobs/review-addresser.ts
@@ -48,7 +48,7 @@ async function processPR(repo: Repo, pr: gh.PR, reviewData: gh.PRReviewData): Pr
         log.warn(`[review-addresser] Failed to update PR description for ${fullName}#${pr.number}: ${descErr}`);
       }
       log.info(`[review-addresser] Pushed changes for ${fullName}#${pr.number}`);
-      notify(`[review-addresser] Addressed review on ${fullName}#${pr.number}`);
+      notify(`[review-addresser] Addressed review on ${fullName}#${pr.number}\n${gh.pullUrl(fullName, pr.number)}`);
     }
 
     if (claudeOutput.trim()) {


### PR DESCRIPTION
## Summary

Adds GitHub links to all Discord notifications so users can click through directly to the relevant issue or PR. Two URL helper functions (`issueUrl` and `pullUrl`) were added to `src/github.ts` and used across all job notification calls.

## Changes

- Added `issueUrl()` and `pullUrl()` helper functions in `src/github.ts` to build GitHub URLs from repo name and number
- Updated all `notify()` calls across 9 jobs (auto-merger, ci-fixer, doc-maintainer, improvement-identifier, issue-refiner, issue-worker, mkdocs-update, plan-reviewer, review-addresser) to append the relevant GitHub link
- Added unit tests for the new URL helpers
- Updated test mocks to include the new functions

Closes #78

Closes #78