### PR TITLE
docs: update mkdocs content for yeti

### DIFF
--- a/site/reference/api.md
+++ b/site/reference/api.md
@@ -31,6 +31,7 @@ The `/health`, `/status`, `/login`, and `POST /login` routes are accessible with
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/` | Main dashboard -- job status, worker queues, running tasks, schedule info |
+| `GET` | `/jobs` | Jobs page -- all registered jobs with backend, model, schedule, status, and controls |
 
 ### Job Control (Auth Required)
 

--- a/site/usage/dashboard.md
+++ b/site/usage/dashboard.md
@@ -100,6 +100,33 @@ Click into any entry to see the full log output --- every line the job produced 
 
 You can also view all log entries related to a specific issue. This is useful when you want to trace the full history of how Yeti processed a particular item: the refinement run, the implementation run, any CI fix attempts, and review addressing.
 
+## Jobs page
+
+The jobs page (`/jobs`) gives you a comprehensive view of every registered job --- both enabled and disabled. It is the go-to place for understanding what Yeti is configured to do and how each job is running.
+
+Each job row shows:
+
+| Column | Description |
+|---|---|
+| **Job** | Name and a short description of what the job does |
+| **Enabled** | Whether the job is in the `enabledJobs` config list |
+| **Backend** | Which AI backend the job uses (Claude or Copilot) |
+| **Model** | The AI model override, or "default" |
+| **Schedule** | Interval (e.g., "Every 5 min") or daily hour (e.g., "Daily at 1:00") |
+| **Status** | Running, Paused, Idle, or Disabled |
+| **Last Run** | Relative time since the last execution |
+| **Next Run** | Countdown to the next scheduled run |
+| **Logs** | Link to the latest run's log (or "Live" if currently running) |
+
+### Controls
+
+Enabled jobs have action buttons:
+
+- **Run** --- Trigger the job immediately
+- **Pause / Resume** --- Toggle whether the job runs on its schedule
+
+The page live-updates every 10 seconds, so you can leave it open to monitor job activity.
+
 ## Config page
 
 The config page (`/config`) lets you view and edit Yeti's configuration directly from the browser.

--- a/site/usage/discord.md
+++ b/site/usage/discord.md
@@ -43,7 +43,7 @@ Yeti posts to your configured channel automatically. You do not need to set anyt
 
 - **Issue audit summaries** --- The `issue-auditor` job posts its nightly findings: mislabeled issues, stale items, anomalies across your repos
 - **Error reports** --- When something goes wrong, the error reporter sends a summary with deduplication (the same error will not flood your channel)
-- **Job activity** --- Completion notifications for significant work
+- **Job activity** --- Notifications for significant work: PRs created, plans produced, CI fixes pushed, reviews addressed, merges completed, and more. Each notification includes a direct GitHub link to the relevant issue or PR.
 
 Notifications are informational. They do not require a response --- just a glance to confirm things are running smoothly, like checking the weather before heading out.
 


### PR DESCRIPTION
## Summary

Documents the new Jobs page added to the web dashboard, updates the API reference to include the `/jobs` route, and expands the Discord notification description to reflect the richer activity messages now sent (with direct GitHub links).

## Changes

- **Added Jobs page documentation** in the dashboard usage guide — covers the column layout (backend, model, schedule, status, timing), action controls (Run, Pause/Resume), and live-update behavior
- **Added `/jobs` route** to the API reference table
- **Updated Discord notifications section** to describe the full range of job activity notifications (PRs created, plans produced, CI fixes, reviews addressed, merges) and mention that each includes a direct GitHub link