### PR TITLE
docs: update documentation for yeti

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -175,6 +175,7 @@ via `AsyncLocalStorage` context). See [Database Schema](database-schema.md).
 Routes:
 
 - `GET /` — Dashboard: job status with Last Run/Next Run columns, "Run" buttons, queue overview
+- `GET /jobs` — Jobs page: all jobs with descriptions, enabled/disabled state, AI backend/model, schedule, Run/Pause controls
 - `GET /health` — JSON health check
 - `GET /status` — JSON with jobs (including `jobSchedules` with per-job `nextRunIn` countdowns), uptime, queue, integrations
 - `GET /login` / `POST /login` — Token-based authentication


### PR DESCRIPTION
## Summary

Updated the HTTP server documentation in `yeti/OVERVIEW.md` to include the `/jobs` route, which was added in a recent feature PR but missing from the routes listing. This keeps the AI-facing documentation accurate for agents that rely on `OVERVIEW.md` for codebase context.

## Changes

- Added `GET /jobs` route entry to the HTTP server routes section in `yeti/OVERVIEW.md`, documenting the Jobs page functionality (job descriptions, enabled/disabled state, AI backend/model, schedule, and Run/Pause controls)