### PR TITLE
fix: resolve #95 — codex parameter error

### DIFF
--- a/src/claude.test.ts
+++ b/src/claude.test.ts
@@ -1115,7 +1115,7 @@ describe("runAI with codex backend", () => {
     // Verify spawn was called with codex binary and correct args
     expect(mockSpawn).toHaveBeenCalledWith(
       "codex",
-      ["--approval-mode", "full-auto", "do the thing"],
+      ["exec", "--full-auto", "do the thing"],
       expect.objectContaining({ cwd: "/tmp/codex-test" }),
     );
 
@@ -1149,7 +1149,7 @@ describe("runAI with codex backend", () => {
     // Model flag should come before the positional prompt
     expect(mockSpawn).toHaveBeenCalledWith(
       "codex",
-      ["--approval-mode", "full-auto", "--model", "o3", "do the thing"],
+      ["exec", "--full-auto", "--model", "o3", "do the thing"],
       expect.objectContaining({ cwd: "/tmp/codex-test" }),
     );
 

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -40,7 +40,7 @@ interface BackendConfig {
 const BACKENDS: Record<AiBackend, BackendConfig> = {
   claude: { binary: "claude", args: ["-p", "--dangerously-skip-permissions"], promptVia: "stdin", name: "Claude" },
   copilot: { binary: "copilot", args: ["--allow-all-tools", "-s", "--no-ask-user"], promptVia: "flag", name: "Copilot" },
-  codex: { binary: "codex", args: ["--approval-mode", "full-auto"], promptVia: "positional", name: "Codex" },
+  codex: { binary: "codex", args: ["exec", "--full-auto"], promptVia: "positional", name: "Codex" },
 };
 
 // ── Bounded concurrent queue ──


### PR DESCRIPTION
## Summary

Fixes the Codex CLI integration by switching from the deprecated `--approval-mode full-auto` flag to the `exec` subcommand with `--full-auto` flag. Codex CLI updated its interface, causing all Codex-backed jobs (like plan-reviewer) to fail with "unexpected argument '--approval-mode' found" errors and produce empty output.

## Changes

- Updated Codex backend args in `src/claude.ts` from `["--approval-mode", "full-auto"]` to `["exec", "--full-auto"]`
- Updated corresponding test expectations in `src/claude.test.ts` to match the new argument format

Closes #95