### PR TITLE
fix: resolve #94 — jobs page shows stale provider/model configuration

### DIFF
--- a/src/pages/jobs.test.ts
+++ b/src/pages/jobs.test.ts
@@ -22,7 +22,7 @@ describe("buildJobsPage", () => {
   const defaultArgs = () => ({
     allJobs: makeJobs(),
     enabledJobs: new Set(["issue-worker", "ci-fixer"]),
-    jobAi: {} as Readonly<Record<string, { backend?: "claude" | "copilot"; model?: string }>>,
+    jobAi: {} as Readonly<Record<string, { backend?: "claude" | "copilot" | "codex"; model?: string }>>,
     runningJobs: { "issue-worker": true, "ci-fixer": false } as Record<string, boolean>,
     latestRuns: new Map([
       ["issue-worker", { runId: "run-1", status: "completed", startedAt: "2025-01-01 00:00:00", completedAt: "2025-01-01 00:01:00" }],
@@ -159,6 +159,26 @@ describe("buildJobsPage", () => {
       args.latestRuns, args.theme, args.paused, args.scheduleInfo,
     );
     expect(html).toContain('href="/logs/run-1"');
+  });
+
+  it("shows Codex backend from JOB_AI config", () => {
+    const args = defaultArgs();
+    args.jobAi = { "ci-fixer": { backend: "codex" } };
+    const html = buildJobsPage(
+      args.allJobs, args.enabledJobs, args.jobAi, args.runningJobs,
+      args.latestRuns, args.theme, args.paused, args.scheduleInfo,
+    );
+    expect(html).toContain("Codex");
+  });
+
+  it("renders id attributes on backend and model cells", () => {
+    const args = defaultArgs();
+    const html = buildJobsPage(
+      args.allJobs, args.enabledJobs, args.jobAi, args.runningJobs,
+      args.latestRuns, args.theme, args.paused, args.scheduleInfo,
+    );
+    expect(html).toContain('id="job-backend-issue-worker"');
+    expect(html).toContain('id="job-model-issue-worker"');
   });
 
   it("shows paused status for paused jobs", () => {

--- a/src/pages/jobs.ts
+++ b/src/pages/jobs.ts
@@ -106,7 +106,7 @@ export function buildJobsPage(
       ? `<span style="color:var(--success)">Enabled</span>`
       : `<span style="color:var(--text-subtle)">Disabled</span>`;
 
-    const backendLabel = backend === "copilot" ? "Copilot" : "Claude";
+    const backendLabel = backend === "copilot" ? "Copilot" : backend === "codex" ? "Codex" : "Claude";
 
     return `<tr>
       <td>
@@ -114,8 +114,8 @@ export function buildJobsPage(
         <div style="font-size:0.8rem;color:var(--text-secondary)">${description}</div>
       </td>
       <td>${enabledBadge}</td>
-      <td>${backendLabel}</td>
-      <td>${model}</td>
+      <td id="job-backend-${name}">${backendLabel}</td>
+      <td id="job-model-${name}">${model}</td>
       <td>${scheduleText}</td>
       <td id="job-${name}" class="${statusClass}">${statusText}</td>
       <td id="job-lastrun-${name}">${lastRunText}</td>
@@ -219,6 +219,19 @@ ${htmlOpenTag(theme)}
               if (lr) lr.textContent = info.lastCompletedAt ? formatRelativeTime(info.lastCompletedAt) : '\u2014';
               var nr = document.getElementById('job-nextrun-' + name);
               if (nr) nr.textContent = info.nextRunIn !== null ? formatCountdown(info.nextRunIn) : '\u2014';
+            });
+          }
+          if (data.jobAi) {
+            document.querySelectorAll('[id^="job-backend-"]').forEach(function(el) {
+              var name = el.id.replace('job-backend-', '');
+              var ai = data.jobAi[name];
+              var backend = ai && ai.backend ? ai.backend : 'claude';
+              el.textContent = backend === 'copilot' ? 'Copilot' : backend === 'codex' ? 'Codex' : 'Claude';
+            });
+            document.querySelectorAll('[id^="job-model-"]').forEach(function(el) {
+              var name = el.id.replace('job-model-', '');
+              var ai = data.jobAi[name];
+              el.textContent = ai && ai.model ? ai.model : 'default';
             });
           }
         })

--- a/src/server.ts
+++ b/src/server.ts
@@ -469,6 +469,7 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
         codexQueue: { pending: cxq.pending, active: cxq.active },
         runningTasks,
         jobSchedules,
+        jobAi: config.JOB_AI,
         discord: discordStatus(),
       }),
     );


### PR DESCRIPTION
## Summary

The jobs dashboard page was displaying stale provider/model configuration because the live-refresh polling endpoint didn't include `jobAi` data, and the frontend had no logic to update backend/model cells dynamically. This fix adds `jobAi` to the `/api/status` response, adds `id` attributes to backend/model table cells, and includes client-side JavaScript to update them on each poll cycle. It also adds support for displaying the "Codex" backend label, which was previously missing.

## Changes

- Added `jobAi: config.JOB_AI` to the `/api/status` JSON response in `src/server.ts`
- Added `id` attributes (`job-backend-{name}`, `job-model-{name}`) to backend and model table cells for DOM targeting
- Added client-side polling logic to update backend and model cells from live `jobAi` data
- Fixed `backendLabel` to recognize `"codex"` as a backend option (previously fell through to "Claude")
- Added tests for Codex backend rendering and `id` attribute presence on cells

Closes #94