### PR TITLE
fix: resolve #96 — job should have logged yeti error but didn't

### DIFF
--- a/src/claude.test.ts
+++ b/src/claude.test.ts
@@ -260,7 +260,7 @@ describe("runClaude", () => {
     expect(stdinMock.end).toHaveBeenCalled();
   });
 
-  it("still resolves stdout on non-zero exit code", async () => {
+  it("rejects on non-zero exit code", async () => {
     const child = new EventEmitter() as ChildProcess & EventEmitter;
     const stdoutEmitter = new EventEmitter();
     const stderrEmitter = new EventEmitter();
@@ -279,8 +279,7 @@ describe("runClaude", () => {
     stderrEmitter.emit("data", Buffer.from("error msg"));
     child.emit("close", 1, null);
 
-    const result = await promise;
-    expect(result).toBe("partial output");
+    await expect(promise).rejects.toThrow("claude exited with code 1: error msg");
   });
 
   it("rejects on spawn error", async () => {
@@ -1156,5 +1155,27 @@ describe("runAI with codex backend", () => {
     stdoutEmitter.emit("data", Buffer.from("ok"));
     child.emit("close", 0, null);
     await promise;
+  });
+
+  it("rejects when codex exits with non-zero code", async () => {
+    const child = new EventEmitter() as ChildProcess & EventEmitter;
+    const stdoutEmitter = new EventEmitter();
+    const stderrEmitter = new EventEmitter();
+    const stdinMock = { write: vi.fn(), end: vi.fn() };
+
+    Object.assign(child, {
+      stdout: stdoutEmitter,
+      stderr: stderrEmitter,
+      stdin: stdinMock,
+    });
+
+    mockSpawn.mockReturnValue(child as any);
+
+    const promise = runAI("do the thing", "/tmp/codex-test", { backend: "codex" });
+
+    stderrEmitter.emit("data", Buffer.from("error: unexpected argument '--approval-mode' found"));
+    child.emit("close", 2, null);
+
+    await expect(promise).rejects.toThrow("Codex exited with code 2");
   });
 });

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -574,6 +574,8 @@ export function runAI(prompt: string, cwd: string, options?: AiOptions): Promise
       }
       if (code !== 0) {
         log.warn(`${config.name} exited with code ${code}: ${stderr.slice(0, 500)}`);
+        reject(new Error(`${config.name} exited with code ${code}: ${stderr.slice(0, 500)}`));
+        return;
       }
       resolve(stdout);
     });
@@ -706,6 +708,8 @@ export function runClaude(prompt: string, cwd: string): Promise<string> {
       }
       if (code !== 0) {
         log.warn(`claude exited with code ${code}: ${stderr.slice(0, 500)}`);
+        reject(new Error(`claude exited with code ${code}: ${stderr.slice(0, 500)}`));
+        return;
       }
       resolve(stdout);
     });

--- a/src/jobs/plan-reviewer.test.ts
+++ b/src/jobs/plan-reviewer.test.ts
@@ -263,4 +263,33 @@ describe("plan-reviewer", () => {
     // Should record failure so it retries
     expect(mockDb.recordTaskFailed).toHaveBeenCalledWith(1, "Empty review output");
   });
+
+  it("reports error when runAI rejects with non-zero exit", async () => {
+    const issue = mockIssue({
+      body: "Test issue body",
+      labels: [{ name: "Needs Plan Review" }],
+    });
+    mockGh.listOpenIssues.mockResolvedValueOnce([issue]);
+    mockGh.getIssueComments.mockResolvedValue([
+      { id: 501, body: planCommentBody, login: "yeti-bot" },
+    ]);
+    mockGh.getCommentReactions.mockResolvedValue([]);
+    mockClaude.runAI.mockRejectedValueOnce(
+      new Error("Codex exited with code 2: error: unexpected argument '--approval-mode' found"),
+    );
+
+    await run([repo]);
+
+    expect(reportError).toHaveBeenCalledWith(
+      "plan-reviewer:process-issue",
+      expect.stringContaining("#1"),
+      expect.any(Error),
+    );
+    expect(mockDb.recordTaskFailed).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Codex exited with code 2"),
+    );
+    expect(mockGh.commentOnIssue).not.toHaveBeenCalled();
+    expect(mockClaude.removeWorktree).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

When an AI backend (Claude CLI or Codex CLI) exited with a non-zero exit code, the promise resolved with whatever partial stdout was captured instead of rejecting with an error. This meant jobs like plan-reviewer silently swallowed failures (e.g., Codex receiving an invalid `--approval-mode` flag), logging a warning but never raising a reportable error. The fix makes `runAI()` and `runClaude()` reject their promises on non-zero exit codes, so errors propagate correctly to job-level error handling.

## Changes

- **`src/claude.ts`**: Both `runAI()` and `runClaude()` now call `reject()` (instead of falling through to `resolve()`) when the child process exits with a non-zero code
- **`src/claude.test.ts`**: Updated existing test from "still resolves stdout on non-zero exit code" to "rejects on non-zero exit code"; added a new test for Codex backend rejection
- **`src/jobs/plan-reviewer.test.ts`**: Added test verifying that a rejected `runAI` call triggers `reportError` and `recordTaskFailed` instead of being silently ignored

Closes #96