### PR TITLE
fix: resolve #100 — Add config option to include forked repos in discovery

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -87,6 +87,7 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
   "skippedItems": [],
   "prioritizedItems": [],
   "allowedRepos": [],
+  "includeForks": false,
   "enabledJobs": [],
   "queueScanIntervalMs": 300000
 }
@@ -117,6 +118,9 @@ if [[ ! -f "$ENV_FILE" ]]; then
 # Codex backend
 # YETI_MAX_CODEX_WORKERS=1
 # YETI_CODEX_TIMEOUT_MS=1200000
+
+# Repo discovery
+# YETI_INCLUDE_FORKS=false
 CONF
   chmod 600 "$ENV_FILE"
   log "Created $ENV_FILE — edit it to set environment overrides"

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,7 @@ export interface ConfigFile {
   skippedItems?: Array<{ repo: string; number: number }>;
   prioritizedItems?: Array<{ repo: string; number: number }>;
   allowedRepos?: string[];
+  includeForks?: boolean;
   enabledJobs?: string[];
   queueScanIntervalMs?: number;
 }
@@ -187,11 +188,13 @@ function loadConfig() {
   const allowedRepos = process.env["YETI_ALLOWED_REPOS"] !== undefined
     ? process.env["YETI_ALLOWED_REPOS"].split(",").map((s) => s.trim()).filter(Boolean)
     : file.allowedRepos ?? null;
+  const includeForks = process.env["YETI_INCLUDE_FORKS"] === "true"
+    || (process.env["YETI_INCLUDE_FORKS"] === undefined && (file.includeForks ?? false));
   const enabledJobs = file.enabledJobs ?? [];
   const jobAi = file.jobAi ?? {};
   const queueScanIntervalMs = file.queueScanIntervalMs ?? 5 * 60 * 1000;
 
-  return { githubOwners, selfRepo, port, intervals, schedules, logRetentionDays, logRetentionPerJob, discordBotToken, discordChannelId, discordAllowedUsers, authToken, maxClaudeWorkers, claudeTimeoutMs, maxCopilotWorkers, copilotTimeoutMs, maxCodexWorkers, codexTimeoutMs, pausedJobs, skippedItems, prioritizedItems, allowedRepos, enabledJobs, jobAi, queueScanIntervalMs };
+  return { githubOwners, selfRepo, port, intervals, schedules, logRetentionDays, logRetentionPerJob, discordBotToken, discordChannelId, discordAllowedUsers, authToken, maxClaudeWorkers, claudeTimeoutMs, maxCopilotWorkers, copilotTimeoutMs, maxCodexWorkers, codexTimeoutMs, pausedJobs, skippedItems, prioritizedItems, allowedRepos, includeForks, enabledJobs, jobAi, queueScanIntervalMs };
 }
 
 const config = loadConfig();
@@ -210,6 +213,7 @@ export let PAUSED_JOBS: readonly string[] = config.pausedJobs;
 export let SKIPPED_ITEMS: ReadonlyArray<{ repo: string; number: number }> = config.skippedItems;
 export let PRIORITIZED_ITEMS: ReadonlyArray<{ repo: string; number: number }> = config.prioritizedItems;
 export let ALLOWED_REPOS: readonly string[] | null = config.allowedRepos;
+export let INCLUDE_FORKS = config.includeForks;
 export let ENABLED_JOBS: readonly string[] = config.enabledJobs;
 export let MAX_COPILOT_WORKERS = config.maxCopilotWorkers;
 export let COPILOT_TIMEOUT_MS = config.copilotTimeoutMs;
@@ -263,6 +267,7 @@ export function reloadConfig(): void {
   SKIPPED_ITEMS = fresh.skippedItems;
   PRIORITIZED_ITEMS = fresh.prioritizedItems;
   ALLOWED_REPOS = fresh.allowedRepos;
+  INCLUDE_FORKS = fresh.includeForks;
   ENABLED_JOBS = fresh.enabledJobs;
   MAX_COPILOT_WORKERS = fresh.maxCopilotWorkers;
   COPILOT_TIMEOUT_MS = fresh.copilotTimeoutMs;

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -25,6 +25,7 @@ vi.mock("./config.js", () => ({
   },
   SELF_REPO: "test-org/test-repo",
   ALLOWED_REPOS: null as readonly string[] | null,
+  INCLUDE_FORKS: false,
   SKIPPED_ITEMS: [],
   PRIORITIZED_ITEMS: [],
 }));
@@ -93,6 +94,7 @@ import {
   clearQueueCacheByCategories,
   issueUrl,
   pullUrl,
+  listAllOrgRepos,
 } from "./github.js";
 
 describe("gh retry logic", () => {
@@ -435,6 +437,74 @@ describe("listRepos", () => {
 
     const repos = await listRepos();
     expect(repos).toEqual([]); // error caught, returns empty
+  });
+
+  it("includes --source flag by default (INCLUDE_FORKS = false)", async () => {
+    const repoData = [
+      { nameWithOwner: "test-owner/repo1", name: "repo1", owner: { login: "test-owner" }, defaultBranchRef: { name: "main" }, isArchived: false },
+    ];
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
+      cb(null, JSON.stringify(repoData), "");
+    });
+
+    await listRepos();
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args).toContain("--source");
+  });
+
+  it("omits --source flag when INCLUDE_FORKS is true", async () => {
+    (config as any).INCLUDE_FORKS = true;
+    const repoData = [
+      { nameWithOwner: "test-owner/repo1", name: "repo1", owner: { login: "test-owner" }, defaultBranchRef: { name: "main" }, isArchived: false },
+    ];
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
+      cb(null, JSON.stringify(repoData), "");
+    });
+
+    await listRepos();
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args).not.toContain("--source");
+    (config as any).INCLUDE_FORKS = false;
+  });
+
+  it("clearRepoCache also invalidates listAllOrgRepos cache", async () => {
+    const repoData = [
+      { nameWithOwner: "test-owner/repo1", name: "repo1", owner: { login: "test-owner" }, defaultBranchRef: { name: "main" }, isArchived: false },
+    ];
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
+      cb(null, JSON.stringify(repoData), "");
+    });
+
+    await listAllOrgRepos();
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+
+    // Without clearing, second call should use cache
+    await listAllOrgRepos();
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+
+    // After clearing, should re-fetch
+    clearRepoCache();
+    await listAllOrgRepos();
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("warns about forks hint when INCLUDE_FORKS is false and allowedRepo not found", async () => {
+    (config as any).ALLOWED_REPOS = ["repo1", "missing-fork"];
+    const repoData = [
+      { nameWithOwner: "test-owner/repo1", name: "repo1", owner: { login: "test-owner" }, defaultBranchRef: { name: "main" }, isArchived: false },
+    ];
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
+      cb(null, JSON.stringify(repoData), "");
+    });
+
+    await listRepos();
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("missing-fork"),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("includeForks"),
+    );
+    (config as any).ALLOWED_REPOS = null;
   });
 });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { GITHUB_OWNERS, LABELS, LABEL_SPECS, SKIPPED_ITEMS, PRIORITIZED_ITEMS, ALLOWED_REPOS, SELF_REPO, type Repo } from "./config.js";
+import { GITHUB_OWNERS, LABELS, LABEL_SPECS, SKIPPED_ITEMS, PRIORITIZED_ITEMS, ALLOWED_REPOS, INCLUDE_FORKS, SELF_REPO, type Repo } from "./config.js";
 import * as log from "./log.js";
 import { notify } from "./notify.js";
 import { reportError } from "./error-reporter.js";
@@ -123,6 +123,7 @@ let repoCachePromise: Promise<Repo[]> | null = null;
 export function clearRepoCache(): void {
   repoCache = null;
   repoCachePromise = null;
+  apiCache.invalidate("all-org-repos");
 }
 
 function filterRepos(repos: Repo[]): Repo[] {
@@ -136,7 +137,8 @@ function filterRepos(repos: Repo[]): Repo[] {
   const discoveredNames = new Set(repos.map(r => r.name.toLowerCase()));
   for (const name of ALLOWED_REPOS) {
     if (!discoveredNames.has(name.toLowerCase()) && name.toLowerCase() !== selfRepoShort) {
-      log.warn(`allowedRepos: "${name}" does not match any discovered repository`);
+      const hint = INCLUDE_FORKS ? "" : " (forked repos are excluded — set includeForks to true to include them)";
+      log.warn(`allowedRepos: "${name}" does not match any discovered repository${hint}`);
     }
   }
 
@@ -406,17 +408,18 @@ async function fetchRepos(): Promise<Repo[]> {
 
   for (const owner of GITHUB_OWNERS) {
     try {
-      const raw = await gh([
+      const args = [
         "repo",
         "list",
         owner,
         "--no-archived",
-        "--source",
+        ...(INCLUDE_FORKS ? [] : ["--source"]),
         "--limit",
         "200",
         "--json",
         "nameWithOwner,name,owner,defaultBranchRef,isArchived",
-      ]);
+      ];
+      const raw = await gh(args);
       const entries: GhRepoEntry[] = safeJsonParse(raw, "repo list");
       for (const e of entries) {
         repos.push({

--- a/src/pages/config.ts
+++ b/src/pages/config.ts
@@ -12,6 +12,7 @@ export function buildConfigPage(saved: boolean, theme: Theme): string {
 
   const envMap: Record<string, string> = {
     allowedRepos: "YETI_ALLOWED_REPOS",
+    includeForks: "YETI_INCLUDE_FORKS",
     githubOwners: "YETI_GITHUB_OWNERS",
     selfRepo: "YETI_SELF_REPO",
     port: "PORT",
@@ -83,6 +84,10 @@ ${htmlOpenTag(theme)}
     <input type="text" name="allowedRepos" id="allowedRepos" value="${escapeHtml(Array.isArray(cfg.allowedRepos) ? (cfg.allowedRepos as string[]).join(", ") : "")}"${isDisabled("allowedRepos") ? " disabled" : ""}>
     ${envNote("allowedRepos")}
     <div class="field-note">Restricts which repos Yeti processes. Empty means no repos (use with caution). To allow all repos, remove the allowedRepos key from config.json.</div>
+
+    <label><input type="checkbox" name="includeForks" value="true" ${cfg.includeForks ? "checked" : ""}${isDisabled("includeForks") ? " disabled" : ""}> Include forked repositories in discovery</label>
+    ${envNote("includeForks")}
+    <div class="field-note">When enabled, forked repos in the org are discovered alongside source repos. Default: off.</div>
 
     <h2>Server</h2>
     <label for="port">Port</label>

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -412,6 +412,33 @@ describe("HTTP server", () => {
     expect(res.body).toMatch(/name="allowedRepos"[^>]*value=""/);
   });
 
+  it("POST /config sets includeForks to true when checkbox checked", async () => {
+    const { writeConfig: wc } = await import("./config.js");
+    await request(server, "POST", "/config", {
+      body: "includeForks=true",
+    });
+    expect(wc).toHaveBeenCalledWith(
+      expect.objectContaining({ includeForks: true }),
+    );
+  });
+
+  it("POST /config sets includeForks to false when checkbox absent", async () => {
+    const { writeConfig: wc } = await import("./config.js");
+    await request(server, "POST", "/config", {
+      body: "selfRepo=org%2Frepo",
+    });
+    expect(wc).toHaveBeenCalledWith(
+      expect.objectContaining({ includeForks: false }),
+    );
+  });
+
+  it("GET /config renders includeForks checkbox", async () => {
+    const res = await request(server, "GET", "/config");
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('name="includeForks"');
+    expect(res.body).toContain("Include forked repositories");
+  });
+
   it("GET /login redirects to / when auth disabled", async () => {
     const res = await request(server, "GET", "/login");
     expect(res.status).toBe(303);

--- a/src/server.ts
+++ b/src/server.ts
@@ -312,6 +312,7 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
     if (params["allowedRepos"] !== undefined) {
       updates.allowedRepos = params["allowedRepos"].split(",").map(s => s.trim()).filter(Boolean);
     }
+    updates.includeForks = params["includeForks"] === "true";
     // Intervals
     const intervalUpdates: Record<string, number> = {};
     for (const [key, value] of Object.entries(params)) {

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -122,7 +122,8 @@ querying GitHub labels — this lightweight scanner runs on its own timer
 are enabled. `clearQueueCacheByCategories()` selectively clears scanner
 categories before each scan to prevent stale entries. The `listRepos()` function
 falls back to a stale cache when the fresh fetch returns empty (transient
-failure protection).
+failure protection). By default, only source (non-fork) repos are discovered;
+set `includeForks` to `true` to include forked repos.
 Provides `issueUrl()` and `pullUrl()` URL builder helpers used by job
 notifications to include clickable GitHub links in Discord messages.
 Provides `isItemSkipped()` and `isItemPrioritized()` helpers that check
@@ -554,8 +555,20 @@ Restricts which repositories Yeti processes. Applied as a filter on `listRepos()
 - `null` = all repos; `[]` = selfRepo only; `["repo-a", "repo-b"]` = those repos + selfRepo
 - `selfRepo` is always included regardless of the list (ensures Yeti can always process its own error issues)
 - Matching is case-insensitive; uses short repo names (not `owner/repo`)
-- Warns at runtime if a configured name doesn't match any discovered repository
+- Warns at runtime if a configured name doesn't match any discovered repository (includes a hint about `includeForks` when fork discovery is disabled)
 - Editable via the dashboard config UI; empty input maps to `[]` (no repos except selfRepo), not `null` (all repos). To restore `null` (all repos), remove the `allowedRepos` key from `config.json` directly.
+
+### includeForks
+
+Controls whether forked repositories are included in discovery.
+
+- **Field**: `includeForks` (boolean)
+- **Env var**: `YETI_INCLUDE_FORKS`
+- **Default**: `false` — only source (non-fork) repos are discovered via `gh repo list --source`
+- **Live-reloadable**: yes (clearing both the repo cache and the all-org-repos cache)
+- When `true`, the `--source` flag is omitted from `gh repo list`, so forks in the org appear alongside source repos
+- Affects both `listRepos()` (worker discovery) and `listAllOrgRepos()` (Repos onboarding page)
+- PRs created on forks stay within the fork — `gh pr create --repo <fork>` targets the fork, not the upstream parent
 
 Config changes made via the web UI (`POST /config`) take effect immediately
 at runtime — no restart required. The config module uses ESM live bindings


### PR DESCRIPTION
## Summary

Adds an `includeForks` boolean config option (default `false`) so forked repositories in the org can be included in discovery. Previously, `fetchRepos()` unconditionally passed `--source` to `gh repo list`, silently excluding all forks — even those explicitly listed in `allowedRepos`, which produced a misleading warning with no hint about the cause.

## Changes

- Added `includeForks` config field (`~/.yeti/config.json`) and `YETI_INCLUDE_FORKS` env var, following existing config priority (env > file > default)
- When `includeForks` is `true`, the `--source` flag is omitted from `gh repo list` so forks appear in discovery
- Improved the `allowedRepos` mismatch warning to include a hint about `includeForks` when fork discovery is disabled
- Added a checkbox toggle for `includeForks` on the dashboard config page
- Wired up `POST /config` to persist the new field and `clearRepoCache()` to also invalidate the `listAllOrgRepos` cache
- Updated `deploy/install.sh` with the new config field and env var placeholder
- Added tests covering the `--source` flag behavior, cache invalidation, warning hint, and dashboard form handling
- Updated `yeti/OVERVIEW.md` with documentation for the new option

Resolves #100

Closes #100