### PR TITLE
docs: update mkdocs content for yeti

### DIFF
--- a/site/getting-started/configuration.md
+++ b/site/getting-started/configuration.md
@@ -39,7 +39,7 @@ For a typical starting point, enable the core workflow jobs:
 ]
 ```
 
-All available jobs: `issue-refiner`, `issue-worker`, `ci-fixer`, `review-addresser`, `auto-merger`, `doc-maintainer`, `repo-standards`, `improvement-identifier`, `issue-auditor`, `triage-yeti-errors`, `plan-reviewer`.
+All available jobs: `issue-refiner`, `issue-worker`, `ci-fixer`, `review-addresser`, `auto-merger`, `doc-maintainer`, `repo-standards`, `improvement-identifier`, `issue-auditor`, `triage-yeti-errors`, `plan-reviewer`, `mkdocs-update`.
 
 ### `githubOwners`
 
@@ -52,6 +52,14 @@ GitHub organizations or usernames whose repositories Yeti should scan. Defaults 
 ### `allowedRepos`
 
 An optional allow-list of specific repositories (by name, not full path) to process. When set, Yeti ignores all other repos under the configured owners. When `null` or omitted, all repos under the owners are eligible.
+
+### `includeForks`
+
+Whether to include forked repositories when scanning for work. Defaults to `false`. Set to `true` if you want Yeti to discover and process issues/PRs in forks.
+
+```json
+"includeForks": true
+```
 
 ```json
 "allowedRepos": ["frontend", "api", "docs"]
@@ -110,7 +118,9 @@ Most configuration changes take effect without restarting the service. When you 
 - `authToken`
 - `maxClaudeWorkers`, `claudeTimeoutMs`
 - `maxCopilotWorkers`, `copilotTimeoutMs`
+- `maxCodexWorkers`, `codexTimeoutMs`
 - `jobAi`
+- `includeForks`
 - `logRetentionDays`, `logRetentionPerJob`
 - `queueScanIntervalMs`
 - `discordAllowedUsers`

--- a/site/index.md
+++ b/site/index.md
@@ -66,7 +66,7 @@ The cold reality: most of the time you spent on an issue was not making decision
 - **Web dashboard** --- Real-time view of job status, work queue, logs, and configuration. Runs on port 9384.
 - **Discord bot** --- Create issues, analyze PRs, trigger jobs, and get notifications from your Discord server
 - **Multi-repo** --- Monitors all repositories under your configured GitHub organizations
-- **Multi-backend AI** --- Route different jobs to Claude or Copilot with per-job model overrides
+- **Multi-backend AI** --- Route different jobs to Claude, Copilot, or Codex with per-job model overrides
 - **Priority queue** --- Mark issues as `Priority` to move them to the front of every queue
 - **Live configuration** --- Most settings reload without restart. Pause jobs, skip items, adjust intervals from the dashboard.
 - **Auto-updates** --- A systemd timer checks for new releases every 60 seconds, downloads them, and restarts with health check and automatic rollback

--- a/site/reference/configuration.md
+++ b/site/reference/configuration.md
@@ -21,6 +21,7 @@ Changes to live-reloadable fields take effect without restarting the service. Ot
 | `allowedRepos` | `string[] \| null` | `null` | `YETI_ALLOWED_REPOS` (comma-sep) | No | Repo allow-list. `null` means all repos under `githubOwners` are scanned |
 | `logRetentionDays` | `number` | `14` | -- | Yes | Delete logs older than N days |
 | `logRetentionPerJob` | `number` | `20` | -- | Yes | Max log runs to keep per job |
+| `includeForks` | `boolean` | `false` | `YETI_INCLUDE_FORKS` | Yes | Include forked repositories when scanning for work |
 | `queueScanIntervalMs` | `number` | `300000` (5 min) | -- | Yes | How often the lightweight queue label scanner runs |
 
 ## AI Backend Settings

--- a/site/reference/jobs/index.md
+++ b/site/reference/jobs/index.md
@@ -80,7 +80,7 @@ Any job can be manually triggered via the dashboard or API (`POST /trigger/:job`
 
 ### AI Backend
 
-Jobs marked "AI: Yes" use Claude CLI by default. Individual jobs can be routed to a different backend (e.g., Copilot) or model via the [`jobAi` config](../configuration.md#example-per-job-ai-overrides).
+Jobs marked "AI: Yes" use Claude CLI by default. Individual jobs can be routed to a different backend (e.g., Copilot or Codex) or model via the [`jobAi` config](../configuration.md#example-per-job-ai-overrides).
 
 ### Rate Limiting
 

--- a/site/usage/optimization.md
+++ b/site/usage/optimization.md
@@ -1,6 +1,6 @@
 # Optimization
 
-Yeti runs standard `claude` and `copilot` CLI sessions inside your repository. Every job that calls AI spawns a real CLI process in a git worktree of your repo --- the same process you'd get if you opened a terminal, `cd`'d into your project, and ran `claude` yourself.
+Yeti runs standard `claude`, `copilot`, and `codex` CLI sessions inside your repository. Every job that calls AI spawns a real CLI process in a git worktree of your repo --- the same process you'd get if you opened a terminal, `cd`'d into your project, and ran `claude` yourself.
 
 This means **all your existing agent configuration applies**. CLAUDE.md files, skills, hooks, settings --- Yeti's AI reads and follows them just like an interactive session would. The quality of Yeti's plans, implementations, and fixes is directly tied to how well your repository is set up for AI agents.
 
@@ -25,9 +25,12 @@ claude -p --dangerously-skip-permissions
 
 # Copilot backend
 copilot --allow-all-tools -s --no-ask-user -p "<prompt>"
+
+# Codex backend
+codex exec --full-auto "<prompt>"
 ```
 
-Both run with full filesystem access in your repo's worktree. The CLI loads whatever configuration it finds there --- exactly as it would in an interactive session.
+All three run with full filesystem access in your repo's worktree. The CLI loads whatever configuration it finds there --- exactly as it would in an interactive session.
 
 ---
 


### PR DESCRIPTION
## Summary

Update documentation to reflect recent feature additions: Codex as a third AI backend option alongside Claude and Copilot, the `includeForks` configuration option for scanning forked repositories, and the `mkdocs-update` job. These docs were out of sync with the current codebase capabilities.

## Changes

- Added Codex CLI references throughout (index, optimization, jobs, configuration) as a supported AI backend
- Documented the `includeForks` config option in both getting-started and reference guides
- Added `mkdocs-update` to the list of available jobs
- Added `maxCodexWorkers` and `codexTimeoutMs` to the live-reloadable config list
- Added Codex CLI invocation example to the optimization guide