### PR TITLE
docs: update documentation for yeti

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -273,7 +273,7 @@ See [Jobs](jobs.md) for detailed behavior of each.
 
 | Job | Trigger | Interval | Summary |
 |-----|---------|----------|---------|
-| `issue-refiner` | Issues labelled `Needs Refinement` | 5 min | Posts implementation plans for issues with `Needs Refinement` label (exempt: `[ci-unrelated]` and `[yeti-error]` issues), refines plans based on unreacted human feedback, responds to follow-up questions on issues with open PRs |
+| `issue-refiner` | Issues labelled `Needs Refinement` | 5 min | Posts implementation plans for issues with `Needs Refinement` label (exempt: `[ci-unrelated]` and `[yeti-error]` issues); asks clarifying questions for underspecified issues instead of guessing; refines plans based on unreacted human feedback; responds to follow-up questions on issues with open PRs |
 | `plan-reviewer` | Issues labelled `Needs Plan Review` | 10 min | Adversarial review of implementation plans using configurable AI backend |
 | `issue-worker` | Label `Refined` | 5 min | Implements the issue, creates a PR |
 | `ci-fixer` | Any open PR with failing checks | 10 min | Resolves merge conflicts, fixes CI failures |

--- a/yeti/jobs.md
+++ b/yeti/jobs.md
@@ -34,6 +34,12 @@ Three modes:
 
 - Creates a worktree on branch `yeti/plan-<N>-<hex4>`
 - Asks Claude for a fresh implementation plan
+- **Clarifying questions**: Before planning, Claude evaluates whether the issue
+  provides enough detail. If the issue is underspecified (ambiguous behavior,
+  unclear scope, missing acceptance criteria), Claude outputs a
+  `### Clarifying Questions` section with targeted questions instead of guessing.
+  The user responds as a comment on the issue, and the existing refinement loop
+  incorporates their answers into a focused plan on the next cycle.
 - Posts the plan as a comment prefixed with `## Implementation Plan`
 - If `plan-reviewer` is in `enabledJobs`: adds `Needs Plan Review` label (triggers adversarial review)
 - Otherwise: adds the `Ready` label (signals "Yeti is done, your turn")


### PR DESCRIPTION
## Summary

Updated documentation to reflect the new clarifying-questions behavior added to the issue-refiner job. When an issue is underspecified, Claude now asks targeted clarifying questions instead of guessing at an implementation plan, and the user's answers feed into the next refinement cycle.

## Changes

- Updated the job summary table in `yeti/OVERVIEW.md` to mention the clarifying-questions capability of issue-refiner
- Added a new "Clarifying questions" subsection to the issue-refiner's first-time planning mode in `yeti/jobs.md`, explaining the evaluation criteria and feedback loop