### PR TITLE
docs: update mkdocs content for yeti

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
           - repo-standards: reference/jobs/repo-standards.md
           - triage-yeti-errors: reference/jobs/triage-yeti-errors.md
           - mkdocs-update: reference/jobs/mkdocs-update.md
+          - prompt-evaluator: reference/jobs/prompt-evaluator.md
 
 extra_css:
   - stylesheets/extra.css

--- a/site/reference/configuration.md
+++ b/site/reference/configuration.md
@@ -78,6 +78,7 @@ All schedule fields live inside the `schedules` object, are specified as hour of
 | `improvementIdentifierHour` | `3` (3 AM) | improvement-identifier run hour |
 | `mkdocsUpdateHour` | `4` (4 AM) | mkdocs-update run hour |
 | `issueAuditorHour` | `5` (5 AM) | issue-auditor run hour |
+| `promptEvaluatorHour` | `0` (Midnight) | prompt-evaluator run hour |
 
 ---
 
@@ -147,7 +148,8 @@ A more complete configuration with intervals, schedules, and integrations:
     "repo-standards",
     "improvement-identifier",
     "issue-auditor",
-    "mkdocs-update"
+    "mkdocs-update",
+    "prompt-evaluator"
   ],
   "intervals": {
     "issueWorkerMs": 300000,
@@ -159,7 +161,8 @@ A more complete configuration with intervals, schedules, and integrations:
     "repoStandardsHour": 2,
     "improvementIdentifierHour": 3,
     "mkdocsUpdateHour": 4,
-    "issueAuditorHour": 5
+    "issueAuditorHour": 5,
+    "promptEvaluatorHour": 0
   },
   "jobAi": {
     "plan-reviewer": { "backend": "copilot" }

--- a/site/reference/jobs/index.md
+++ b/site/reference/jobs/index.md
@@ -29,6 +29,7 @@ These jobs run once daily at a configured hour (local timezone). They also run o
 | [improvement-identifier](improvement-identifier.md) | 3 AM | Yes | Find codebase improvements and implement them as PRs |
 | [mkdocs-update](mkdocs-update.md) | 4 AM | Yes | Update MkDocs documentation sites |
 | [issue-auditor](issue-auditor.md) | 5 AM | No | Audit and fix issue label state |
+| [prompt-evaluator](prompt-evaluator.md) | Midnight | Yes | A/B test prompts and file issues for improvements |
 
 ---
 
@@ -60,7 +61,7 @@ Add more jobs as you grow comfortable with the workflow:
 - **`repo-standards`** -- Keeps labels in sync
 - **`review-addresser`** -- Handles PR review comments
 
-The full set including nightly jobs (`doc-maintainer`, `improvement-identifier`, `issue-auditor`, `mkdocs-update`) rounds out a fully autonomous setup.
+The full set including nightly jobs (`doc-maintainer`, `improvement-identifier`, `issue-auditor`, `mkdocs-update`, `prompt-evaluator`) rounds out a fully autonomous setup.
 
 ---
 

--- a/site/reference/jobs/issue-refiner.md
+++ b/site/reference/jobs/issue-refiner.md
@@ -44,10 +44,11 @@ The refiner processes an issue when any of these conditions are met:
 1. Creates an isolated git worktree for the repository
 2. Reads the issue body, all comments, and any referenced images
 3. Instructs Claude to read `yeti/OVERVIEW.md` and linked docs for codebase context
-4. Claude produces the plan (text only, no code changes)
-5. Posts an `## Implementation Plan` comment on the issue
-6. Transitions labels: removes `Needs Refinement`, adds `Needs Plan Review` or `Ready`
-7. For `[ci-unrelated]` issues: also adds `Refined` to skip human approval
+4. Claude evaluates whether the issue provides enough detail for a confident plan -- if underspecified, it outputs a `### Clarifying Questions` section with specific questions and instructs the user to respond as a comment
+5. Claude produces the plan (text only, no code changes) for aspects that are sufficiently clear
+6. Posts an `## Implementation Plan` comment on the issue
+7. Transitions labels: removes `Needs Refinement`, adds `Needs Plan Review` or `Ready`
+8. For `[ci-unrelated]` issues: also adds `Refined` to skip human approval
 
 ### Refinement (Feedback Loop)
 

--- a/site/reference/jobs/prompt-evaluator.md
+++ b/site/reference/jobs/prompt-evaluator.md
@@ -1,0 +1,63 @@
+# prompt-evaluator
+
+> Automated self-improvement: A/B tests Yeti's own prompts and files issues when a better variant is found.
+
+| Property | Value |
+|----------|-------|
+| Type | Scheduled |
+| Default hour | Midnight (`schedules.promptEvaluatorHour`) |
+| Uses AI | Yes |
+| Backend | Claude (configurable via `jobAi`) |
+| Config key | `schedules.promptEvaluatorHour` |
+
+## What it does
+
+The prompt-evaluator is a self-improvement mechanism for Yeti's plan-producing prompts. It reads the source code of registered prompt functions, generates an improved variant via AI, A/B tests both the current and variant prompts against synthetic GitHub issues, has AI judge the outputs, and files a GitHub issue (labeled `prompt-improvement`) when the variant wins convincingly.
+
+Humans review and approve before any prompt change is applied -- no automatic modifications are made.
+
+## Prompt Registry
+
+The evaluator rotates through a registry of prompt functions, evaluating one per run:
+
+| Prompt | Source File | Purpose |
+|--------|-------------|---------|
+| `buildNewPlanPrompt` | `src/jobs/issue-refiner.ts` | Produce an initial implementation plan from a GitHub issue |
+| `buildRefinementPrompt` | `src/jobs/issue-refiner.ts` | Refine an existing plan based on human feedback |
+| `buildFollowUpPrompt` | `src/jobs/issue-refiner.ts` | Answer follow-up questions while a PR is open |
+| `buildReviewPrompt` | `src/jobs/plan-reviewer.ts` | Critically review an implementation plan |
+| `buildPrompt` (issue-worker) | `src/jobs/issue-worker.ts` | Implement a solution based on an issue's plan |
+
+State is persisted to `~/.yeti/prompt-eval-state.json` so each run picks up the next prompt in the registry.
+
+## How it works
+
+1. **Read prompt source** -- Creates a worktree from the default branch and reads the source file containing the target prompt function
+2. **Generate test inputs** -- Asks AI to produce 4 test cases: 2 realistic GitHub issues (one well-specified, one vague) and 2 adversarial edge cases
+3. **Generate variant** -- Asks AI to analyze the current prompt for weaknesses and propose an improved version with a rationale
+4. **A/B comparison** -- Runs both the current prompt and the variant against all 4 test cases, collecting outputs
+5. **Judge** -- An AI judge scores each output pair on four criteria (1--5 scale):
+    - **Specificity** -- Does it reference concrete files, functions, or patterns?
+    - **Actionability** -- Could a developer implement from this output?
+    - **Scope awareness** -- Does it avoid over- or under-engineering?
+    - **Uncertainty** -- Does it flag ambiguity instead of guessing?
+6. **Report** -- If the variant wins at least 3 of 4 test cases, files a GitHub issue with the full evaluation report
+
+## Duplicate Prevention
+
+Before filing an issue, the evaluator searches for existing open issues with the same title. If one already exists, it skips filing to avoid duplicates.
+
+## Output
+
+When the variant wins, the filed issue includes:
+
+- The rationale for the proposed change
+- Per-test-case results with scores, winner, and reasoning
+- Collapsible sections showing the full current and variant outputs
+- The `prompt-improvement` label for easy filtering
+
+## Related jobs
+
+- [issue-refiner](issue-refiner.md) -- Source of most evaluated prompts
+- [plan-reviewer](plan-reviewer.md) -- Source of the review prompt
+- [issue-worker](issue-worker.md) -- Source of the implementation prompt


### PR DESCRIPTION
## Summary

Documents the new `prompt-evaluator` job across the MkDocs site. This job was added in #112 but its documentation was not yet included in the docs site. Updates cover the new job's dedicated reference page, configuration options, and integration into existing job listings.

## Changes

- Add new reference page for `prompt-evaluator` job covering its purpose, prompt registry, A/B testing workflow, and duplicate prevention
- Add `prompt-evaluator` to the mkdocs nav and jobs index table
- Document `promptEvaluatorHour` schedule config and add the job to the example configuration
- Update `issue-refiner` docs to reflect the new clarifying-questions step added in #110
- Add `prompt-evaluator` to the list of nightly jobs in the recommended setup guide