### PR TITLE
docs: update documentation for yeti

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -64,7 +64,7 @@ deploy/
 
 **`main.ts`** — Wires everything together. Initializes the SQLite database,
 recovers orphaned tasks from a previous crash (cleans up dangling worktrees,
-marks tasks failed), prunes old logs, registers all 12 jobs with the scheduler
+marks tasks failed), prunes old logs, registers all 13 jobs with the scheduler
 (interval jobs staggered by 2 seconds to prevent thundering herd), starts the
 HTTP server, launches the **queue label scanner** (an infrastructure timer that
 runs `scanQueueLabels()` on a configurable interval to keep the dashboard queue
@@ -537,6 +537,7 @@ defaults.
 | `schedules.improvementIdentifierHour` | — | `3` (3 AM local time) |
 | `schedules.mkdocsUpdateHour` | — | `4` (4 AM local time) |
 | `schedules.issueAuditorHour` | — | `5` (5 AM local time) |
+| `schedules.promptEvaluatorHour` | — | `0` (midnight local time) |
 | `logRetentionDays` | — | `14` |
 | `logRetentionPerJob` | — | `20` |
 | `discordBotToken` | `YETI_DISCORD_BOT_TOKEN` | *(empty — Discord disabled if unset)* |
@@ -565,7 +566,7 @@ Controls which jobs are registered with the scheduler at startup.
 - **Field**: `enabledJobs` (string array)
 - **Default**: `[]` — no jobs run if the field is absent or empty
 - **Live-reloadable**: yes (changes take effect without restart)
-- **Available values**: `issue-worker`, `issue-refiner`, `plan-reviewer`, `ci-fixer`, `review-addresser`, `doc-maintainer`, `auto-merger`, `repo-standards`, `improvement-identifier`, `issue-auditor`, `triage-yeti-errors`, `mkdocs-update`
+- **Available values**: `issue-worker`, `issue-refiner`, `plan-reviewer`, `ci-fixer`, `review-addresser`, `doc-maintainer`, `auto-merger`, `repo-standards`, `improvement-identifier`, `issue-auditor`, `triage-yeti-errors`, `mkdocs-update`, `prompt-evaluator`
 
 **Migration note**: existing configs without `enabledJobs` will have no jobs start after upgrading. Add the desired job names to `enabledJobs` in `~/.yeti/config.json` before upgrading.
 

--- a/yeti/jobs.md
+++ b/yeti/jobs.md
@@ -478,3 +478,50 @@ which issues were fixed.
 
 Per-repo errors are caught and reported without blocking other repos.
 
+## prompt-evaluator
+
+**Source**: `src/jobs/prompt-evaluator.ts`
+**Trigger**: Daily schedule
+**Schedule**: Runs at hour configured by `schedules.promptEvaluatorHour`
+(default: midnight / 0 AM local time)
+
+A self-improvement mechanism that A/B tests Yeti's plan-producing prompts
+against AI-generated improved variants. Evaluates one prompt per run,
+cycling through the `PROMPT_REGISTRY` round-robin (state persisted in
+`~/.yeti/prompt-eval-state.json`).
+
+**Registered prompts** (5 total):
+
+| Prompt | Source file | Purpose |
+|--------|------------|---------|
+| `buildNewPlanPrompt` | `issue-refiner.ts` | Initial implementation plan from a GitHub issue |
+| `buildRefinementPrompt` | `issue-refiner.ts` | Refine a plan based on human feedback |
+| `buildFollowUpPrompt` | `issue-refiner.ts` | Answer follow-up questions on an issue with an open PR |
+| `buildReviewPrompt` | `plan-reviewer.ts` | Critically review an implementation plan |
+| `buildPrompt` (issue-worker) | `issue-worker.ts` | Implement a solution based on a plan |
+
+**Evaluation pipeline** (all AI calls use the job's configured backend via
+`JOB_AI["prompt-evaluator"]`):
+
+1. **Read source**: Creates a read-only worktree, reads the prompt function's
+   source code from the registered file
+2. **Generate test inputs**: Asks AI to produce 4 diverse test cases (2
+   realistic GitHub issues + 2 adversarial edge cases). Aborts if fewer
+   than 4 are returned.
+3. **Generate variant**: Asks AI to analyze the prompt for weaknesses and
+   propose an improved version with a rationale
+4. **A/B comparison**: For each test case, runs both the current prompt and
+   the variant prompt, collecting outputs
+5. **Judge**: For each test case, an AI judge scores both outputs on 4
+   criteria (specificity, actionability, scope-awareness, uncertainty
+   handling) on a 1–5 scale and declares a winner
+6. **Report**: If the variant wins at least 3 of 4 test cases, files a
+   GitHub issue in `SELF_REPO` with the `prompt-improvement` label
+   containing full scores, reasoning, and collapsible output comparisons.
+   Deduplicates by checking for existing issues with the same title.
+
+The `prompt-improvement` label signals that a human should review the
+proposed prompt change before applying it — no automatic prompt
+modifications are made. Notifications are sent when an improvement is
+found.
+


### PR DESCRIPTION
## Summary

Documents the new `prompt-evaluator` job added in #112. Updates the overview to reflect the new job count (13), adds its schedule config and `enabledJobs` entry, and provides a full job reference section.

## Changes

- Updated job count from 12 to 13 in `yeti/OVERVIEW.md`
- Added `schedules.promptEvaluatorHour` to the configuration reference table
- Added `prompt-evaluator` to the `enabledJobs` available values list
- Added full `prompt-evaluator` job documentation in `yeti/jobs.md` covering the evaluation pipeline, registered prompts, and reporting behavior