### PR TITLE
fix: resolve #113 — [yeti-error] auto-merger:process-pr

### DIFF
--- a/src/jobs/auto-merger.test.ts
+++ b/src/jobs/auto-merger.test.ts
@@ -301,6 +301,41 @@ describe("auto-merger", () => {
     expect(log.warn).not.toHaveBeenCalled();
   });
 
+  it("skips PR when branch protection blocks merge", async () => {
+    const pr = mockPR({ author: { login: "dependabot[bot]" } });
+    mockGh.listPRs.mockResolvedValue([pr]);
+    mockGh.getPRCheckStatus.mockResolvedValue("passing");
+    mockGh.mergePR.mockRejectedValue(
+      new Error("gh pr merge 91 --repo frostyard/intuneme --squash failed: X Pull request frostyard/intuneme#91 is not mergeable: the base branch policy prohibits the merge."),
+    );
+
+    await run([repo]);
+
+    expect(mockGh.mergePR).toHaveBeenCalledWith(repo.fullName, pr.number);
+    expect(mockNotify).not.toHaveBeenCalled();
+    expect(reportError).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      `[auto-merger] ${repo.fullName}#${pr.number} has branch protection, skipping`,
+    );
+    expect(mockGh.removeLabel).not.toHaveBeenCalled();
+  });
+
+  it("still reports non-branch-protection merge errors", async () => {
+    const pr = mockPR({ author: { login: "dependabot[bot]" } });
+    mockGh.listPRs.mockResolvedValue([pr]);
+    mockGh.getPRCheckStatus.mockResolvedValue("passing");
+    mockGh.mergePR.mockRejectedValue(new Error("API error"));
+
+    await run([repo]);
+
+    expect(reportError).toHaveBeenCalledWith(
+      "auto-merger:process-pr",
+      `${repo.fullName}#${pr.number}`,
+      expect.any(Error),
+    );
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
   it("checks mergeable state before merging", async () => {
     const pr = mockPR({ author: { login: "dependabot[bot]" } });
     mockGh.listPRs.mockResolvedValue([pr]);

--- a/src/jobs/auto-merger.ts
+++ b/src/jobs/auto-merger.ts
@@ -59,7 +59,15 @@ export async function run(repos: Repo[]): Promise<void> {
 
           gh.populateQueueCache("auto-mergeable", repo.fullName, { number: pr.number, title: pr.title, type: "pr", updatedAt: pr.updatedAt, priority: gh.hasPriorityLabel(pr.labels) });
           log.info(`[auto-merger] Merging ${repo.fullName}#${pr.number}: ${pr.title}`);
-          await gh.mergePR(repo.fullName, pr.number);
+          try {
+            await gh.mergePR(repo.fullName, pr.number);
+          } catch (err) {
+            if (err instanceof Error && err.message.includes("base branch policy prohibits the merge")) {
+              log.info(`[auto-merger] ${repo.fullName}#${pr.number} has branch protection, skipping`);
+              continue;
+            }
+            throw err;
+          }
           notify(`[auto-merger] Merged ${repo.fullName}#${pr.number}\n${gh.pullUrl(repo.fullName, pr.number)}`);
 
           if (isYetiPR) {


### PR DESCRIPTION
## Summary

The auto-merger job was crashing with an error when attempting to merge PRs in repos that have branch protection rules requiring additional conditions (e.g., required reviews, status checks). This fix catches the specific "base branch policy prohibits the merge" error from `gh pr merge` and gracefully skips the PR instead of reporting it as an error, since branch protection is expected behavior, not a fault.

## Changes

- Wrap `gh.mergePR()` in a try/catch that detects branch protection errors via the `"base branch policy prohibits the merge"` message substring
- Skip the PR with an informational log when branch protection blocks the merge, rather than escalating to the error reporter
- Re-throw all other merge errors so they continue to be reported normally
- Add tests for both the branch-protection skip path and the passthrough of unrelated merge errors

Closes #113