### PR TITLE
fix: include variant prompt text in prompt-evaluator issues

### DIFF
--- a/src/jobs/prompt-evaluator.test.ts
+++ b/src/jobs/prompt-evaluator.test.ts
@@ -355,7 +355,7 @@ describe("parseJudgment", () => {
 
 describe("buildReport", () => {
   it("includes prompt name in title", () => {
-    const report = buildReport("buildNewPlanPrompt", "rationale text", [
+    const report = buildReport("buildNewPlanPrompt", "the variant prompt text", "rationale text", [
       {
         testCase: { title: "Test", body: "Body" },
         currentOutput: "current output",
@@ -368,7 +368,7 @@ describe("buildReport", () => {
   });
 
   it("includes test case details in body", () => {
-    const report = buildReport("buildNewPlanPrompt", "rationale text", [
+    const report = buildReport("buildNewPlanPrompt", "the variant prompt text", "rationale text", [
       {
         testCase: { title: "Test issue", body: "Issue body" },
         currentOutput: "current output",
@@ -380,5 +380,6 @@ describe("buildReport", () => {
     expect(report.body).toContain("current output");
     expect(report.body).toContain("variant output");
     expect(report.body).toContain("rationale text");
+    expect(report.body).toContain("the variant prompt text");
   });
 });

--- a/src/jobs/prompt-evaluator.ts
+++ b/src/jobs/prompt-evaluator.ts
@@ -193,6 +193,7 @@ interface EvalResult {
 
 export function buildReport(
   promptName: string,
+  variantPromptText: string,
   rationale: string,
   results: EvalResult[],
 ): { title: string; body: string } {
@@ -235,6 +236,16 @@ export function buildReport(
     `### Proposed Change Rationale`,
     ``,
     rationale,
+    ``,
+    `### Proposed Variant Prompt`,
+    ``,
+    `<details><summary>Click to expand the full variant prompt text</summary>`,
+    ``,
+    "```",
+    variantPromptText,
+    "```",
+    ``,
+    `</details>`,
     ``,
     `---`,
     ``,
@@ -437,7 +448,7 @@ async function evaluatePrompt(entry: PromptEntry, repo: Repo): Promise<void> {
       if (existing.length > 0) {
         log.info(`[prompt-evaluator] Skipping — similar issue already exists: #${existing[0].number}`);
       } else {
-        const report = buildReport(entry.name, variant.rationale, results);
+        const report = buildReport(entry.name, variant.variant, variant.rationale, results);
         const issueNumber = await gh.createIssue(SELF_REPO, report.title, report.body, ["prompt-improvement"]);
         log.info(`[prompt-evaluator] Created issue #${issueNumber} for ${entry.name}`);
         notify(`[prompt-evaluator] Improvement found for ${entry.name} — issue #${issueNumber}\n${gh.issueUrl(SELF_REPO, issueNumber)}`);


### PR DESCRIPTION
## Summary
- The prompt-evaluator report was missing the actual proposed variant prompt text, making issues like #120 impossible to act on without re-running the evaluation
- `buildReport` now includes the full variant prompt in a collapsible `<details>` section between the rationale and test results

## Test plan
- [x] `npm test` — all 1632 tests pass
- [x] buildReport test verifies variant text appears in body

🤖 Generated with [Claude Code](https://claude.com/claude-code)