### PR TITLE
refactor: Use LABELS constant instead of hardcoded string in discord assign command

### DIFF
--- a/src/discord.test.ts
+++ b/src/discord.test.ts
@@ -31,6 +31,7 @@ const { mockConfig, mockClient, mockEventHandlers, mockChannel } = vi.hoisted(()
       DISCORD_ALLOWED_USERS: [] as string[],
       GITHUB_OWNERS: ["frostyard"],
       JOB_AI: {} as Record<string, unknown>,
+      LABELS: { refined: "Refined", ready: "Ready", priority: "Priority", inReview: "In Review", needsRefinement: "Needs Refinement", needsPlanReview: "Needs Plan Review" },
     },
     mockClient,
     mockEventHandlers,

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,5 +1,5 @@
 import { Client, GatewayIntentBits, type Message, type TextChannel } from "discord.js";
-import { DISCORD_BOT_TOKEN, DISCORD_CHANNEL_ID, DISCORD_ALLOWED_USERS, GITHUB_OWNERS, JOB_AI } from "./config.js";
+import { DISCORD_BOT_TOKEN, DISCORD_CHANNEL_ID, DISCORD_ALLOWED_USERS, GITHUB_OWNERS, JOB_AI, LABELS } from "./config.js";
 import * as log from "./log.js";
 import * as gh from "./github.js";
 import * as db from "./db.js";
@@ -284,7 +284,7 @@ async function handleCommand(command: string, args: string[], message: Message):
         await message.reply(`Unknown repo: **${args[0].split("#")[0]}**`);
         return;
       }
-      await gh.addLabel(ref.repo, ref.number, "Refined");
+      await gh.addLabel(ref.repo, ref.number, LABELS.refined);
       await message.reply(`Labeled **${ref.repo}#${ref.number}** as Refined`);
       break;
     }


### PR DESCRIPTION
In `src/discord.ts` line 287, the `assign` command uses the hardcoded string `"Refined"` instead of the `LABELS.refined` constant from `src/config.ts`. Every other module in the codebase uses the `LABELS` constants for label names. If the label name ever changes in config, this command would silently apply the wrong label. Import `LABELS` from config and use `LABELS.refined` instead.

---
*Automated improvement by yeti improvement-identifier*