### PR TITLE
refactor: Fix client-side onclick injection in queue page prioritize/deprioritize toggle

### DIFF
--- a/src/pages/queue.ts
+++ b/src/pages/queue.ts
@@ -236,7 +236,7 @@ ${htmlOpenTag(theme)}
           btn.textContent = 'Deprioritise';
           btn.className = 'prio-btn deprio';
           btn.disabled = false;
-          btn.setAttribute('onclick', "deprioritizeItem('" + repo + "'," + number + ",this)");
+          btn.onclick = function() { deprioritizeItem(repo, number, btn); };
         }
       }).catch(function() {
         btn.textContent = 'Error';
@@ -259,7 +259,7 @@ ${htmlOpenTag(theme)}
           btn.textContent = 'Prioritise';
           btn.className = 'prio-btn';
           btn.disabled = false;
-          btn.setAttribute('onclick', "prioritizeItem('" + repo + "'," + number + ",this)");
+          btn.onclick = function() { prioritizeItem(repo, number, btn); };
         }
       }).catch(function() {
         btn.textContent = 'Error';


### PR DESCRIPTION
In `src/pages/queue.ts`, the `prioritizeItem()` (line 239) and `deprioritizeItem()` (line 262) JavaScript functions use `setAttribute('onclick', ...)` with unescaped string concatenation of the `repo` parameter. While GitHub repo names have restricted character sets making exploitation unlikely, this is still unsafe practice — if `repo` contained a single quote, it would break the onclick handler or allow script injection. The initial HTML rendering (lines 83-93) correctly uses `escapeHtml()`, but the client-side toggle does not re-escape. Fix by using `addEventListener` with a closure instead of `setAttribute('onclick', ...)`, or escape the repo value before interpolation.

---
*Automated improvement by yeti improvement-identifier*