### PR TITLE
docs: update mkdocs content for yeti

### DIFF
--- a/site/reference/jobs/auto-merger.md
+++ b/site/reference/jobs/auto-merger.md
@@ -56,6 +56,10 @@ All categories share these requirements:
 - PR must be in `MERGEABLE` state (no conflicts)
 - PR must not be skipped via `skippedItems` config
 
+### Branch Protection Handling
+
+If a merge fails because the target repository has branch protection rules that prohibit the merge, the auto-merger skips that PR and continues with the remaining queue. This prevents a single protected repository from blocking merges in other repositories.
+
 ### Post-Merge Cleanup
 
 After merging a `yeti/issue-*` PR:

--- a/site/reference/jobs/issue-refiner.md
+++ b/site/reference/jobs/issue-refiner.md
@@ -53,12 +53,19 @@ The refiner processes an issue when any of these conditions are met:
 ### Refinement (Feedback Loop)
 
 1. Detects unreacted human comments after the most recent plan
-2. Feeds the existing plan and new feedback to Claude
+2. Feeds the existing plan and new feedback to Claude with instructions to:
+    - Address each feedback item individually (never silently drop feedback; explain disagreements)
+    - Preserve plan sections not affected by the feedback to avoid regressions
+    - Stay within the original issue scope (out-of-scope suggestions go in a separate `### Out of Scope` section)
+    - Output a `### Clarifying Questions` section if any feedback is ambiguous or contradictory, rather than guessing
+    - Include a testing approach for verifying the changes
 3. Claude produces an updated plan
 4. **Edits the existing plan comment** in-place (does not create a new comment)
 5. If Claude includes a `### Note` section, it is posted as a separate comment
 6. Reacts with thumbsup to each addressed feedback comment
 7. Re-adds `Needs Plan Review` or `Ready`
+
+When no specific feedback is provided (e.g., a re-plan via label), the refiner asks Claude to re-evaluate the plan for missing files, edge cases, implementation order, and testing sufficiency.
 
 ### Follow-Up Response
 

--- a/site/reference/jobs/prompt-evaluator.md
+++ b/site/reference/jobs/prompt-evaluator.md
@@ -59,6 +59,7 @@ Before filing an issue, the evaluator searches for existing open issues with the
 When the variant wins, the filed issue includes:
 
 - The rationale for the proposed change
+- The full variant prompt text in a collapsible section, so reviewers can see the exact proposed change
 - Per-test-case results with scores, winner, and reasoning
 - Collapsible sections showing the full current and variant outputs
 - The `prompt-improvement` label for easy filtering


### PR DESCRIPTION
## Summary

Updates mkdocs documentation to reflect recent code changes across three jobs. These docs capture branch protection handling in auto-merger, improved refinement prompt behavior in issue-refiner, and richer issue content from prompt-evaluator.

## Changes

- **auto-merger**: Added "Branch Protection Handling" section documenting skip behavior when merge fails due to branch protection rules
- **issue-refiner**: Expanded refinement feedback loop documentation with explicit prompt instructions (feedback addressing, scope control, clarifying questions, testing approach) and documented re-plan behavior when no specific feedback is provided
- **prompt-evaluator**: Documented that filed improvement issues now include the full variant prompt text in a collapsible section