### PR TITLE
fix: use numeric iss claim in GitHub App JWT

### DIFF
--- a/src/github-app.test.ts
+++ b/src/github-app.test.ts
@@ -139,7 +139,7 @@ describe("generateJWT", () => {
     const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
 
     const now = Math.floor(Date.now() / 1000);
-    expect(payload.iss).toBe("12345");
+    expect(payload.iss).toBe(12345); // must be numeric, not string
     expect(payload.iat).toBe(now - 30);
     expect(payload.exp).toBe(now + 600);
 

--- a/src/github-app.ts
+++ b/src/github-app.ts
@@ -126,7 +126,7 @@ export function generateJWT(): string {
   const now = Math.floor(Date.now() / 1000);
   const header = { alg: "RS256", typ: "JWT" };
   const payload = {
-    iss: GITHUB_APP_ID,
+    iss: Number(GITHUB_APP_ID), // GitHub requires iss to be numeric, not a string
     iat: now - 30, // 30s backdate for clock drift
     exp: now + 10 * 60, // 10 min
   };


### PR DESCRIPTION
## Summary

- GitHub requires the `iss` (issuer) JWT claim to be a numeric App ID, not a string
- Config stores it as a string (`"12345"`), so `JSON.stringify` was producing `{"iss":"12345"}` instead of `{"iss":12345}`
- GitHub rejected the JWT with "A JSON web token could not be decoded (HTTP 401)"
- Fixed by converting with `Number(GITHUB_APP_ID)` before signing

## Test plan

- [x] `npm test` passes — updated assertion to verify `iss` is numeric
- [ ] Manual: restart Yeti with App config, verify successful init in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)