### PR TITLE
fix: use GET /user/orgs for OAuth org membership check

### DIFF
--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -87,8 +87,8 @@ describe("exchangeCodeForUser", () => {
           json: () => Promise.resolve({ login: "testuser" }),
         })
         .mockResolvedValueOnce({
-          status: 204,
           ok: true,
+          json: () => Promise.resolve([{ login: "test-org" }, { login: "other-org" }]),
         }),
     );
 
@@ -101,8 +101,8 @@ describe("exchangeCodeForUser", () => {
     expect(fetchMock.mock.calls[0][0]).toBe("https://github.com/login/oauth/access_token");
     // User identity
     expect(fetchMock.mock.calls[1][0]).toBe("https://api.github.com/user");
-    // Org membership check
-    expect(fetchMock.mock.calls[2][0]).toBe("https://api.github.com/orgs/test-org/members/testuser");
+    // Org list
+    expect(fetchMock.mock.calls[2][0]).toBe("https://api.github.com/user/orgs?per_page=100");
   });
 
   it("returns null when token exchange fails", async () => {
@@ -149,7 +149,7 @@ describe("exchangeCodeForUser", () => {
     expect(result).toBeNull();
   });
 
-  it("returns not_org_member error when user is not a member of any org", async () => {
+  it("returns not_org_member error when user is not a member of any configured org", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn()
@@ -161,16 +161,18 @@ describe("exchangeCodeForUser", () => {
           ok: true,
           json: () => Promise.resolve({ login: "outsider" }),
         })
-        // Both org checks return 404
-        .mockResolvedValueOnce({ status: 404, ok: false })
-        .mockResolvedValueOnce({ status: 404, ok: false }),
+        // User's orgs don't include any configured owner
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve([{ login: "unrelated-org" }]),
+        }),
     );
 
     const result = await exchangeCodeForUser("test-code");
     expect(result).toEqual({ error: "not_org_member" });
   });
 
-  it("tolerates non-org entries in GITHUB_OWNERS (404) but returns not_org_member", async () => {
+  it("returns not_org_member when user has no orgs", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn()
@@ -182,17 +184,17 @@ describe("exchangeCodeForUser", () => {
           ok: true,
           json: () => Promise.resolve({ login: "testuser" }),
         })
-        // First owner (test-org) returns 404 (not an org or not a member)
-        .mockResolvedValueOnce({ status: 404, ok: false })
-        // Second owner (personal-user) also returns 404
-        .mockResolvedValueOnce({ status: 404, ok: false }),
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve([]),
+        }),
     );
 
     const result = await exchangeCodeForUser("test-code");
     expect(result).toEqual({ error: "not_org_member" });
   });
 
-  it("succeeds if second org matches (OR logic)", async () => {
+  it("matches org names case-insensitively", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn()
@@ -204,14 +206,36 @@ describe("exchangeCodeForUser", () => {
           ok: true,
           json: () => Promise.resolve({ login: "testuser" }),
         })
-        // First owner fails
-        .mockResolvedValueOnce({ status: 404, ok: false })
-        // Second owner succeeds
-        .mockResolvedValueOnce({ status: 204, ok: true }),
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve([{ login: "Test-Org" }]),
+        }),
     );
 
     const result = await exchangeCodeForUser("test-code");
     expect(result).toEqual({ login: "testuser" });
+  });
+
+  it("returns null on transient error fetching org list", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ access_token: "ghu_test" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ login: "testuser" }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+        }),
+    );
+
+    const result = await exchangeCodeForUser("test-code");
+    expect(result).toBeNull();
   });
 
   it("handles network error gracefully", async () => {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -82,44 +82,34 @@ export async function exchangeCodeForUser(code: string): Promise<OAuthResult> {
     return null;
   }
 
-  // Step 3: Check org membership (OR logic across GITHUB_OWNERS)
-  let hadDefinitiveNoMember = false;
-  let hadTransientError = false;
-  for (const owner of GITHUB_OWNERS) {
-    try {
-      const memberRes = await fetch(
-        `https://api.github.com/orgs/${encodeURIComponent(owner)}/members/${encodeURIComponent(login)}`,
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            Accept: "application/json",
-          },
-        },
-      );
-      if (memberRes.status === 204) {
+  // Step 3: Check org membership via user's own org list.
+  // GET /user/orgs lists the authenticated user's orgs (requires read:org scope).
+  // This avoids the circular permission issue with GET /orgs/{org}/members/{username},
+  // which requires the requester to already be an org member.
+  const allowedOwners = new Set(GITHUB_OWNERS.map(o => o.toLowerCase()));
+  try {
+    const orgsRes = await fetch("https://api.github.com/user/orgs?per_page=100", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+    });
+    if (!orgsRes.ok) {
+      log.warn(`OAuth org list fetch failed: HTTP ${orgsRes.status}`);
+      return null; // Transient error — don't blame the user
+    }
+    const orgs = (await orgsRes.json()) as Array<{ login?: string }>;
+    for (const org of orgs) {
+      if (org.login && allowedOwners.has(org.login.toLowerCase())) {
         return { login };
       }
-      if (memberRes.status === 404 || memberRes.status === 302) {
-        // 404 = not a member or not an org; 302 = requester is not an org member
-        hadDefinitiveNoMember = true;
-      } else {
-        // 5xx, 403, etc. — transient or unexpected
-        log.warn(`OAuth org check for ${owner} returned HTTP ${memberRes.status}`);
-        hadTransientError = true;
-      }
-    } catch (err) {
-      log.warn(`OAuth org check for ${owner} failed: ${err}`);
-      hadTransientError = true;
     }
+  } catch (err) {
+    log.warn(`OAuth org list fetch failed: ${err}`);
+    return null; // Transient error — don't blame the user
   }
 
-  if (hadTransientError && !hadDefinitiveNoMember) {
-    // All owners failed with errors — don't blame the user
-    log.warn(`OAuth org membership check failed for ${login} due to transient errors`);
-    return null;
-  }
-
-  log.warn(`OAuth user ${login} is not a member of any configured org`);
+  log.warn(`OAuth user ${login} is not a member of any configured org (${GITHUB_OWNERS.join(", ")})`);
   return { error: "not_org_member" };
 }
 


### PR DESCRIPTION
## Summary

- `GET /orgs/{org}/members/{username}` requires the requester to already be an org member — circular permission problem for self-checks, causing all OAuth logins to get "not a member" errors
- Switched to `GET /user/orgs` which lists the authenticated user's own orgs (uses the `read:org` scope already requested)
- Case-insensitive matching against configured `githubOwners`
- Transient API errors (5xx, network) return generic OAuth error instead of false "not a member" denial

## Test plan

- [x] `npm test` passes (2519 tests, updated org membership tests)
- [ ] Manual: sign in with GitHub as an org member — should succeed now

🤖 Generated with [Claude Code](https://claude.com/claude-code)