### PR TITLE
fix: add debug logging for OAuth org membership check

### DIFF
--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -85,6 +85,7 @@ describe("exchangeCodeForUser", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ login: "testuser" }),
+          headers: new Headers({ "x-oauth-scopes": "read:org" }),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -160,6 +161,7 @@ describe("exchangeCodeForUser", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ login: "outsider" }),
+          headers: new Headers({ "x-oauth-scopes": "read:org" }),
         })
         // User's orgs don't include any configured owner
         .mockResolvedValueOnce({
@@ -183,6 +185,7 @@ describe("exchangeCodeForUser", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ login: "testuser" }),
+          headers: new Headers({ "x-oauth-scopes": "read:org" }),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -205,6 +208,7 @@ describe("exchangeCodeForUser", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ login: "testuser" }),
+          headers: new Headers({ "x-oauth-scopes": "read:org" }),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -227,6 +231,7 @@ describe("exchangeCodeForUser", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ login: "testuser" }),
+          headers: new Headers({ "x-oauth-scopes": "read:org" }),
         })
         .mockResolvedValueOnce({
           ok: false,

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -71,6 +71,8 @@ export async function exchangeCodeForUser(code: string): Promise<OAuthResult> {
       log.warn(`OAuth user identity fetch failed: HTTP ${userRes.status}`);
       return null;
     }
+    const scopes = userRes.headers.get("x-oauth-scopes") ?? "(none)";
+    log.info(`[oauth] Token scopes: ${scopes}`);
     const userData = (await userRes.json()) as { login?: string };
     if (!userData.login) {
       log.warn("OAuth user identity missing login field");
@@ -99,6 +101,8 @@ export async function exchangeCodeForUser(code: string): Promise<OAuthResult> {
       return null; // Transient error — don't blame the user
     }
     const orgs = (await orgsRes.json()) as Array<{ login?: string }>;
+    const orgLogins = orgs.map(o => o.login).filter(Boolean);
+    log.info(`[oauth] User ${login} belongs to orgs: [${orgLogins.join(", ")}], allowed: [${[...allowedOwners].join(", ")}]`);
     for (const org of orgs) {
       if (org.login && allowedOwners.has(org.login.toLowerCase())) {
         return { login };


### PR DESCRIPTION
## Summary

Adds debug logging to diagnose why OAuth org membership checks are failing:

- Logs the token's actual `x-oauth-scopes` header (reveals if `read:org` scope was granted)
- Logs the user's org list from `GET /user/orgs` vs the configured `githubOwners`

This will show whether:
1. The token is missing the `read:org` scope (user needs to re-authorize)
2. The org list is empty (scope issue or user not in any org)
3. The org names don't match (case/spelling mismatch)

## Test plan

- [x] `npm test` passes
- [ ] Deploy, attempt OAuth login, check `journalctl -u yeti` for the new log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)