### PR TITLE
fix: use installation token for OAuth org membership check

### DIFF
--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -53,13 +53,13 @@ describe("isOAuthConfigured", () => {
 });
 
 describe("getAuthorizationUrl", () => {
-  it("builds correct GitHub authorize URL with read:org scope", () => {
+  it("builds correct GitHub authorize URL without scope (App OAuth ignores it)", () => {
     const url = getAuthorizationUrl("random-state-123");
     expect(url).toContain("https://github.com/login/oauth/authorize?");
     expect(url).toContain("client_id=test-client-id");
     expect(url).toContain("redirect_uri=https%3A%2F%2Fyeti.example.com%2Fauth%2Fcallback");
     expect(url).toContain("state=random-state-123");
-    expect(url).toContain("scope=read%3Aorg");
+    expect(url).not.toContain("scope");
   });
 });
 
@@ -68,13 +68,15 @@ describe("exchangeCodeForUser", () => {
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
+    process.env["GH_TOKEN"] = "ghs_installation_token";
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    delete process.env["GH_TOKEN"];
   });
 
-  it("exchanges code for token, gets user, checks org membership", async () => {
+  it("exchanges code for token, gets user, checks org membership via installation token", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn()
@@ -85,12 +87,10 @@ describe("exchangeCodeForUser", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ login: "testuser" }),
-          headers: new Headers({ "x-oauth-scopes": "read:org" }),
+          headers: new Headers({ "x-oauth-scopes": "" }),
         })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve([{ login: "test-org" }, { login: "other-org" }]),
-        }),
+        // Org membership check returns 204 (is a member)
+        .mockResolvedValueOnce({ status: 204 }),
     );
 
     const result = await exchangeCodeForUser("test-code");
@@ -98,12 +98,11 @@ describe("exchangeCodeForUser", () => {
 
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    // Token exchange
     expect(fetchMock.mock.calls[0][0]).toBe("https://github.com/login/oauth/access_token");
-    // User identity
     expect(fetchMock.mock.calls[1][0]).toBe("https://api.github.com/user");
-    // Org list
-    expect(fetchMock.mock.calls[2][0]).toBe("https://api.github.com/user/orgs?per_page=100");
+    // Org check uses installation token, not user token
+    expect(fetchMock.mock.calls[2][0]).toBe("https://api.github.com/orgs/test-org/members/testuser");
+    expect(fetchMock.mock.calls[2][1].headers.Authorization).toBe("Bearer ghs_installation_token");
   });
 
   it("returns null when token exchange fails", async () => {
@@ -150,7 +149,7 @@ describe("exchangeCodeForUser", () => {
     expect(result).toBeNull();
   });
 
-  it("returns not_org_member error when user is not a member of any configured org", async () => {
+  it("returns not_org_member when membership check returns 404", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn()
@@ -161,20 +160,18 @@ describe("exchangeCodeForUser", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ login: "outsider" }),
-          headers: new Headers({ "x-oauth-scopes": "read:org" }),
+          headers: new Headers({ "x-oauth-scopes": "" }),
         })
-        // User's orgs don't include any configured owner
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve([{ login: "unrelated-org" }]),
-        }),
+        // All org checks return 404 (not a member)
+        .mockResolvedValueOnce({ status: 404 })
+        .mockResolvedValueOnce({ status: 404 }),
     );
 
     const result = await exchangeCodeForUser("test-code");
     expect(result).toEqual({ error: "not_org_member" });
   });
 
-  it("returns not_org_member when user has no orgs", async () => {
+  it("returns null on transient error during org membership check", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn()
@@ -185,19 +182,17 @@ describe("exchangeCodeForUser", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ login: "testuser" }),
-          headers: new Headers({ "x-oauth-scopes": "read:org" }),
+          headers: new Headers({ "x-oauth-scopes": "" }),
         })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve([]),
-        }),
+        .mockResolvedValueOnce({ status: 500 }),
     );
 
     const result = await exchangeCodeForUser("test-code");
-    expect(result).toEqual({ error: "not_org_member" });
+    expect(result).toBeNull();
   });
 
-  it("matches org names case-insensitively", async () => {
+  it("returns null when no installation token is available", async () => {
+    delete process.env["GH_TOKEN"];
     vi.stubGlobal(
       "fetch",
       vi.fn()
@@ -208,34 +203,7 @@ describe("exchangeCodeForUser", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ login: "testuser" }),
-          headers: new Headers({ "x-oauth-scopes": "read:org" }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve([{ login: "Test-Org" }]),
-        }),
-    );
-
-    const result = await exchangeCodeForUser("test-code");
-    expect(result).toEqual({ login: "testuser" });
-  });
-
-  it("returns null on transient error fetching org list", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn()
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ access_token: "ghu_test" }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ login: "testuser" }),
-          headers: new Headers({ "x-oauth-scopes": "read:org" }),
-        })
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 500,
+          headers: new Headers({ "x-oauth-scopes": "" }),
         }),
     );
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -16,11 +16,12 @@ export function isOAuthConfigured(): boolean {
 }
 
 export function getAuthorizationUrl(state: string): string {
+  // Note: GitHub App OAuth ignores the scope parameter — permissions come from the
+  // App's configured permissions. We omit scope intentionally.
   const params = new URLSearchParams({
     client_id: GITHUB_APP_CLIENT_ID,
     redirect_uri: `${EXTERNAL_URL}/auth/callback`,
     state,
-    scope: "read:org",
   });
   return `https://github.com/login/oauth/authorize?${params.toString()}`;
 }
@@ -84,33 +85,40 @@ export async function exchangeCodeForUser(code: string): Promise<OAuthResult> {
     return null;
   }
 
-  // Step 3: Check org membership via user's own org list.
-  // GET /user/orgs lists the authenticated user's orgs (requires read:org scope).
-  // This avoids the circular permission issue with GET /orgs/{org}/members/{username},
-  // which requires the requester to already be an org member.
-  const allowedOwners = new Set(GITHUB_OWNERS.map(o => o.toLowerCase()));
-  try {
-    const orgsRes = await fetch("https://api.github.com/user/orgs?per_page=100", {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        Accept: "application/json",
-      },
-    });
-    if (!orgsRes.ok) {
-      log.warn(`OAuth org list fetch failed: HTTP ${orgsRes.status}`);
-      return null; // Transient error — don't blame the user
-    }
-    const orgs = (await orgsRes.json()) as Array<{ login?: string }>;
-    const orgLogins = orgs.map(o => o.login).filter(Boolean);
-    log.info(`[oauth] User ${login} belongs to orgs: [${orgLogins.join(", ")}], allowed: [${[...allowedOwners].join(", ")}]`);
-    for (const org of orgs) {
-      if (org.login && allowedOwners.has(org.login.toLowerCase())) {
+  // Step 3: Check org membership using the installation token.
+  // GitHub App user OAuth tokens don't support scopes — permissions come from the
+  // App config. Using the installation token (which has Organization > Members: Read)
+  // avoids this limitation. GET /orgs/{org}/members/{username} returns 204 if member.
+  const installationToken = process.env["GH_TOKEN"];
+  if (!installationToken) {
+    log.warn("[oauth] No installation token available for org membership check");
+    return null;
+  }
+
+  for (const owner of GITHUB_OWNERS) {
+    try {
+      const memberRes = await fetch(
+        `https://api.github.com/orgs/${encodeURIComponent(owner)}/members/${encodeURIComponent(login)}`,
+        {
+          headers: {
+            Authorization: `Bearer ${installationToken}`,
+            Accept: "application/json",
+          },
+        },
+      );
+      log.info(`[oauth] Org check ${owner}/${login}: HTTP ${memberRes.status}`);
+      if (memberRes.status === 204) {
         return { login };
       }
+      // 404 = not a member or not an org — try next owner
+      if (memberRes.status !== 404) {
+        log.warn(`[oauth] Unexpected status ${memberRes.status} checking ${owner} membership`);
+        return null; // Transient/permission error — don't blame the user
+      }
+    } catch (err) {
+      log.warn(`[oauth] Org check for ${owner} failed: ${err}`);
+      return null; // Transient error
     }
-  } catch (err) {
-    log.warn(`OAuth org list fetch failed: ${err}`);
-    return null; // Transient error — don't blame the user
   }
 
   log.warn(`OAuth user ${login} is not a member of any configured org (${GITHUB_OWNERS.join(", ")})`);


### PR DESCRIPTION
## Summary

- GitHub App OAuth **ignores the `scope` parameter** — user tokens get permissions from the App config, not OAuth scopes
- This meant `read:org` was never granted, `GET /user/orgs` returned empty, and all logins were rejected
- Fix: use the **installation token** (`process.env.GH_TOKEN`) for org membership via `GET /orgs/{org}/members/{username}` instead of the user's OAuth token
- Removed the useless `scope=read:org` from the authorize URL

**Manual step required**: Add **Organization > Members: Read** permission to the GitHub App settings, then accept the updated permissions on the installation page.

## Test plan

- [x] `npm test` passes (2518 tests)
- [ ] Manual: add Members:Read to App, merge + deploy, sign in with GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)